### PR TITLE
Switch to overloaded record dot

### DIFF
--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -103,7 +103,9 @@ library
     FlexibleContexts
     FlexibleInstances
     MultiParamTypeClasses
+    NoFieldSelectors
     NumericUnderscores
+    OverloadedRecordDot
     OverloadedStrings
     ScopedTypeVariables
     TypeApplications

--- a/source/library/Monadoc/Action/App/Log.hs
+++ b/source/library/Monadoc/Action/App/Log.hs
@@ -17,7 +17,7 @@ import qualified Witch
 run :: Severity.Severity -> Text.Text -> App.App ()
 run severity message = do
   context <- Reader.ask
-  Monad.when (severity >= Config.severity (Context.config context)) $ do
+  Monad.when (severity >= context.config.severity) $ do
     let handle = if severity >= Severity.Warn then IO.stderr else IO.stdout
     timestamp <- Timestamp.getCurrentTime
     IO.liftIO . Say.hSay handle $

--- a/source/library/Monadoc/Action/App/Sql.hs
+++ b/source/library/Monadoc/Action/App/Sql.hs
@@ -16,7 +16,7 @@ withConnection ::
   App.AppT m a
 withConnection callback = do
   context <- Reader.ask
-  Pool.withResourceLifted (Context.pool context) callback
+  Pool.withResourceLifted context.pool callback
 
 query :: (Sql.FromRow r, Sql.ToRow q) => Query.Query -> q -> App.App [r]
 query q r = withConnection $ \c -> IO.liftIO $ Sql.query c (Witch.from q) r

--- a/source/library/Monadoc/Action/Blob/Upsert.hs
+++ b/source/library/Monadoc/Action/Blob/Upsert.hs
@@ -7,7 +7,7 @@ import qualified Monadoc.Type.App as App
 
 run :: Blob.Blob -> App.App Blob.Model
 run blob = do
-  maybeModel <- Blob.Query.getByHash $ Blob.hash blob
+  maybeModel <- Blob.Query.getByHash blob.hash
   case maybeModel of
     Nothing -> Blob.Insert.run blob
     Just model -> pure model

--- a/source/library/Monadoc/Action/Blob/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Blob/UpsertSpec.hs
@@ -29,4 +29,4 @@ spec = Hspec.describe "Monadoc.Action.Blob.Upsert" $ do
   Hspec.it "inserts two blobs" . Test.run $ do
     blob1 <- Blob.Upsert.run $ Blob.new "a"
     blob2 <- Blob.Upsert.run $ Blob.new "b"
-    IO.liftIO $ Model.key blob1 `Hspec.shouldNotBe` Model.key blob2
+    IO.liftIO $ blob1.key `Hspec.shouldNotBe` blob2.key

--- a/source/library/Monadoc/Action/Component/Upsert.hs
+++ b/source/library/Monadoc/Action/Component/Upsert.hs
@@ -13,7 +13,7 @@ run component = do
   r1 <-
     App.Sql.query
       "select key from component where type = ? and name = ? limit 1"
-      (Component.type_ component, Component.name component)
+      (component.type_, component.name)
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/Component/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Component/UpsertSpec.hs
@@ -33,4 +33,4 @@ spec = Hspec.describe "Monadoc.Action.Component.Upsert" $ do
     component2 <- do
       x <- Test.arbitraryWith $ \y -> y {Component.name = Witch.unsafeFrom @String "b"}
       Component.Upsert.run x
-    IO.liftIO $ Model.key component1 `Hspec.shouldNotBe` Model.key component2
+    IO.liftIO $ component1.key `Hspec.shouldNotBe` component2.key

--- a/source/library/Monadoc/Action/CronEntry/Enqueue.hs
+++ b/source/library/Monadoc/Action/CronEntry/Enqueue.hs
@@ -44,7 +44,7 @@ runOne cronEntry = do
   pure (job, newCronEntry)
 
 enqueueJob :: CronEntry.Model -> App.App Job.Model
-enqueueJob = Job.Enqueue.run . (.task) . (.value)
+enqueueJob = Job.Enqueue.run . (.value.task)
 
 updateRunAt :: CronEntry.Model -> App.App CronEntry.Model
 updateRunAt cronEntry = do

--- a/source/library/Monadoc/Action/CronEntry/Enqueue.hs
+++ b/source/library/Monadoc/Action/CronEntry/Enqueue.hs
@@ -25,8 +25,8 @@ run = do
       App.Log.debug $
         F.sformat
           ("[worker] enqueued" F.%+ Key.format F.%+ "as" F.%+ Key.format)
-          (Model.key cronEntry)
-          (Model.key job)
+          cronEntry.key
+          job.key
       run
 
 maybeRunOne :: App.App (Maybe (Job.Model, CronEntry.Model))
@@ -44,19 +44,19 @@ runOne cronEntry = do
   pure (job, newCronEntry)
 
 enqueueJob :: CronEntry.Model -> App.App Job.Model
-enqueueJob = Job.Enqueue.run . CronEntry.task . Model.value
+enqueueJob = Job.Enqueue.run . (.task) . (.value)
 
 updateRunAt :: CronEntry.Model -> App.App CronEntry.Model
 updateRunAt cronEntry = do
   now <- Timestamp.getCurrentTime
   runAt <- nextRunAt now cronEntry
-  let newCronEntry = cronEntry {Model.value = (Model.value cronEntry) {CronEntry.runAt = runAt}}
+  let newCronEntry = cronEntry {Model.value = cronEntry.value {CronEntry.runAt = runAt}}
   CronEntry.Update.run newCronEntry
   pure newCronEntry
 
 nextRunAt :: Timestamp.Timestamp -> CronEntry.Model -> App.App Timestamp.Timestamp
 nextRunAt now cronEntry = do
-  let schedule = CronEntry.schedule $ Model.value cronEntry
+  let schedule = cronEntry.value.schedule
   case Saturn.nextMatch (Witch.from now) (Witch.from schedule) of
     Nothing -> Traced.throw $ NoNextMatch.NoNextMatch now schedule
     Just nextMatch -> pure $ Witch.into @Timestamp.Timestamp nextMatch

--- a/source/library/Monadoc/Action/CronEntry/EnqueueSpec.hs
+++ b/source/library/Monadoc/Action/CronEntry/EnqueueSpec.hs
@@ -28,7 +28,7 @@ spec = Hspec.describe "Monadoc.Action.CronEntry.Enqueue" $ do
     cronEntry <- Test.arbitraryWith $ \x -> x {CronEntry.runAt = now, CronEntry.schedule = schedule}
     model <- CronEntry.Insert.run cronEntry
     CronEntry.Enqueue.run
-    actual <- CronEntry.Query.getByKey $ Model.key model
+    actual <- CronEntry.Query.getByKey model.key
     let expected =
           Just
             model

--- a/source/library/Monadoc/Action/CronEntry/Prune.hs
+++ b/source/library/Monadoc/Action/CronEntry/Prune.hs
@@ -15,10 +15,10 @@ import qualified Witch
 
 run :: App.App ()
 run = do
-  let toKeep = Set.fromList $ Maybe.mapMaybe CronEntry.guid CronEntry.all
-  cronEntries <- App.Sql.query_ "select * from cronEntry where guid is not null"
+  let toKeep = Set.fromList $ Maybe.mapMaybe (.guid) CronEntry.all
+  cronEntries <- App.Sql.query_ @CronEntry.Model "select * from cronEntry where guid is not null"
   Monad.forM_ cronEntries $ \cronEntry ->
-    case CronEntry.guid $ Model.value cronEntry of
+    case cronEntry.value.guid of
       Nothing -> pure ()
       Just guid -> Monad.when (Set.notMember guid toKeep) $ do
         CronEntry.Delete.run guid

--- a/source/library/Monadoc/Action/CronEntry/PruneSpec.hs
+++ b/source/library/Monadoc/Action/CronEntry/PruneSpec.hs
@@ -20,7 +20,7 @@ spec = Hspec.describe "Monadoc.Action.CronEntry.Prune" $ do
       x <- Test.arbitraryWith $ \y -> y {CronEntry.guid = Nothing}
       CronEntry.Insert.run x
     CronEntry.Prune.run
-    result <- CronEntry.Query.getByKey $ Model.key cronEntry
+    result <- CronEntry.Query.getByKey cronEntry.key
     IO.liftIO $ result `Hspec.shouldBe` Just cronEntry
 
   Hspec.it "removes a cron entry with a guid" . Test.run $ do
@@ -29,16 +29,16 @@ spec = Hspec.describe "Monadoc.Action.CronEntry.Prune" $ do
       x <- Test.arbitraryWith $ \y -> y {CronEntry.guid = Just guid}
       CronEntry.Insert.run x
     CronEntry.Prune.run
-    result <- CronEntry.Query.getByKey $ Model.key cronEntry
+    result <- CronEntry.Query.getByKey cronEntry.key
     IO.liftIO $ result `Hspec.shouldBe` Nothing
 
   Hspec.it "keeps a cron entry with a static guid" . Test.run $
-    case fmap CronEntry.guid CronEntry.all of
+    case fmap (.guid) CronEntry.all of
       Just guid : _ -> do
         cronEntry <- do
           x <- Test.arbitraryWith $ \y -> y {CronEntry.guid = Just guid}
           CronEntry.Insert.run x
         CronEntry.Prune.run
-        result <- CronEntry.Query.getByKey $ Model.key cronEntry
+        result <- CronEntry.Query.getByKey cronEntry.key
         IO.liftIO $ result `Hspec.shouldBe` Just cronEntry
       _ -> IO.liftIO $ False `Hspec.shouldBe` True

--- a/source/library/Monadoc/Action/CronEntry/Update.hs
+++ b/source/library/Monadoc/Action/CronEntry/Update.hs
@@ -9,9 +9,9 @@ run :: CronEntry.Model -> App.App ()
 run cronEntry =
   App.Sql.execute
     "update cronEntry set guid = ?, runAt = ?, schedule = ?, task = ? where key = ?"
-    ( CronEntry.guid $ Model.value cronEntry,
-      CronEntry.runAt $ Model.value cronEntry,
-      CronEntry.schedule $ Model.value cronEntry,
-      CronEntry.task $ Model.value cronEntry,
-      Model.key cronEntry
+    ( cronEntry.value.guid,
+      cronEntry.value.runAt,
+      cronEntry.value.schedule,
+      cronEntry.value.task,
+      cronEntry.key
     )

--- a/source/library/Monadoc/Action/CronEntry/UpdateSpec.hs
+++ b/source/library/Monadoc/Action/CronEntry/UpdateSpec.hs
@@ -19,14 +19,14 @@ spec = Hspec.describe "Monadoc.Action.CronEntry.Update" $ do
       x <- Test.arbitrary
       CronEntry.Insert.run x
     CronEntry.Update.run cronEntry
-    result <- CronEntry.Query.getByKey $ Model.key cronEntry
+    result <- CronEntry.Query.getByKey cronEntry.key
     IO.liftIO $ result `Hspec.shouldBe` Just cronEntry
 
   Hspec.it "updates a cron entry" . Test.run $ do
     cronEntry1 <- do
       x <- Test.arbitrary
       CronEntry.Insert.run x
-    cronEntry2 <- Test.arbitraryWith $ \x -> x {Model.key = Model.key cronEntry1}
+    cronEntry2 <- Test.arbitraryWith $ \x -> x {Model.key = cronEntry1.key}
     CronEntry.Update.run cronEntry2
-    result <- CronEntry.Query.getByKey $ Model.key cronEntry2
+    result <- CronEntry.Query.getByKey cronEntry2.key
     IO.liftIO $ result `Hspec.shouldBe` Just cronEntry2

--- a/source/library/Monadoc/Action/CronEntry/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/CronEntry/UpsertSpec.hs
@@ -16,30 +16,30 @@ spec = Hspec.describe "Monadoc.Action.CronEntry.Upsert" $ do
   Hspec.it "inserts a dynamic cron entry" . Test.run $ do
     cronEntry <- Test.arbitraryWith $ \x -> x {CronEntry.guid = Nothing}
     Monad.void $ CronEntry.Upsert.run cronEntry
-    cronEntries <- App.Sql.query_ "select * from cronEntry"
-    IO.liftIO $ fmap Model.value cronEntries `Hspec.shouldBe` [cronEntry]
+    cronEntries <- App.Sql.query_ @CronEntry.Model "select * from cronEntry"
+    IO.liftIO $ fmap (.value) cronEntries `Hspec.shouldBe` [cronEntry]
 
   Hspec.it "duplicates a dynamic cron entry" . Test.run $ do
     cronEntry <- Test.arbitraryWith $ \x -> x {CronEntry.guid = Nothing}
     Monad.void $ CronEntry.Upsert.run cronEntry
     Monad.void $ CronEntry.Upsert.run cronEntry
-    cronEntries <- App.Sql.query_ "select * from cronEntry"
-    IO.liftIO $ fmap Model.value cronEntries `Hspec.shouldBe` [cronEntry, cronEntry]
+    cronEntries <- App.Sql.query_ @CronEntry.Model "select * from cronEntry"
+    IO.liftIO $ fmap (.value) cronEntries `Hspec.shouldBe` [cronEntry, cronEntry]
 
   Hspec.it "inserts a static cron entry" . Test.run $ do
     guid <- Test.arbitrary
     cronEntry <- Test.arbitraryWith $ \x -> x {CronEntry.guid = Just guid}
     Monad.void $ CronEntry.Upsert.run cronEntry
-    cronEntries <- App.Sql.query_ "select * from cronEntry"
-    IO.liftIO $ fmap Model.value cronEntries `Hspec.shouldBe` [cronEntry]
+    cronEntries <- App.Sql.query_ @CronEntry.Model "select * from cronEntry"
+    IO.liftIO $ fmap (.value) cronEntries `Hspec.shouldBe` [cronEntry]
 
   Hspec.it "does not duplicate a static cron entry" . Test.run $ do
     guid <- Test.arbitrary
     cronEntry <- Test.arbitraryWith $ \x -> x {CronEntry.guid = Just guid}
     Monad.void $ CronEntry.Upsert.run cronEntry
     Monad.void $ CronEntry.Upsert.run cronEntry
-    cronEntries <- App.Sql.query_ "select * from cronEntry"
-    IO.liftIO $ fmap Model.value cronEntries `Hspec.shouldBe` [cronEntry]
+    cronEntries <- App.Sql.query_ @CronEntry.Model "select * from cronEntry"
+    IO.liftIO $ fmap (.value) cronEntries `Hspec.shouldBe` [cronEntry]
 
   Hspec.it "updates a static cron entry" . Test.run $ do
     guid <- Test.arbitrary
@@ -55,8 +55,8 @@ spec = Hspec.describe "Monadoc.Action.CronEntry.Upsert" $ do
         }
     Monad.void $ CronEntry.Upsert.run cronEntry1
     Monad.void $ CronEntry.Upsert.run cronEntry2
-    cronEntries <- App.Sql.query_ "select * from cronEntry"
-    IO.liftIO $ fmap Model.value cronEntries `Hspec.shouldBe` [cronEntry2]
+    cronEntries <- App.Sql.query_ @CronEntry.Model "select * from cronEntry"
+    IO.liftIO $ fmap (.value) cronEntries `Hspec.shouldBe` [cronEntry2]
 
   Hspec.it "does not update a static cron entry with the same schedule and task" . Test.run $ do
     guid <- Test.arbitrary
@@ -64,10 +64,10 @@ spec = Hspec.describe "Monadoc.Action.CronEntry.Upsert" $ do
     cronEntry2 <- Test.arbitraryWith $ \x ->
       x
         { CronEntry.guid = Just guid,
-          CronEntry.schedule = CronEntry.schedule cronEntry1,
-          CronEntry.task = CronEntry.task cronEntry1
+          CronEntry.schedule = cronEntry1.schedule,
+          CronEntry.task = cronEntry1.task
         }
     Monad.void $ CronEntry.Upsert.run cronEntry1
     Monad.void $ CronEntry.Upsert.run cronEntry2
-    cronEntries <- App.Sql.query_ "select * from cronEntry"
-    IO.liftIO $ fmap Model.value cronEntries `Hspec.shouldBe` [cronEntry1]
+    cronEntries <- App.Sql.query_ @CronEntry.Model "select * from cronEntry"
+    IO.liftIO $ fmap (.value) cronEntries `Hspec.shouldBe` [cronEntry1]

--- a/source/library/Monadoc/Action/Dependency/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Dependency/UpsertSpec.hs
@@ -18,10 +18,10 @@ spec = Hspec.describe "Monadoc.Action.Dependency.Upsert" $ do
     range <- Factory.newRange
     dependency <- Test.arbitraryWith $ \x ->
       x
-        { Dependency.packageMetaComponent = Model.key packageMetaComponent,
-          Dependency.package = Model.key package,
-          Dependency.component = Model.key component,
-          Dependency.range = Model.key range
+        { Dependency.packageMetaComponent = packageMetaComponent.key,
+          Dependency.package = package.key,
+          Dependency.component = component.key,
+          Dependency.range = range.key
         }
     actual <- Dependency.Upsert.run dependency
     let expected = Model.Model {Model.key = Witch.from @Int 1, Model.value = dependency}
@@ -34,10 +34,10 @@ spec = Hspec.describe "Monadoc.Action.Dependency.Upsert" $ do
     range <- Factory.newRange
     dependency <- Test.arbitraryWith $ \x ->
       x
-        { Dependency.packageMetaComponent = Model.key packageMetaComponent,
-          Dependency.package = Model.key package,
-          Dependency.component = Model.key component,
-          Dependency.range = Model.key range
+        { Dependency.packageMetaComponent = packageMetaComponent.key,
+          Dependency.package = package.key,
+          Dependency.component = component.key,
+          Dependency.range = range.key
         }
     old <- Dependency.Upsert.run dependency
     new <- Dependency.Upsert.run dependency
@@ -50,19 +50,19 @@ spec = Hspec.describe "Monadoc.Action.Dependency.Upsert" $ do
     component1 <- Factory.newComponent
     dependency1 <- Test.arbitraryWith $ \x ->
       x
-        { Dependency.packageMetaComponent = Model.key packageMetaComponent,
-          Dependency.package = Model.key package,
-          Dependency.component = Model.key component1,
-          Dependency.range = Model.key range
+        { Dependency.packageMetaComponent = packageMetaComponent.key,
+          Dependency.package = package.key,
+          Dependency.component = component1.key,
+          Dependency.range = range.key
         }
     model1 <- Dependency.Upsert.run dependency1
     component2 <- Factory.newComponent
     dependency2 <- Test.arbitraryWith $ \x ->
       x
-        { Dependency.packageMetaComponent = Model.key packageMetaComponent,
-          Dependency.package = Model.key package,
-          Dependency.component = Model.key component2,
-          Dependency.range = Model.key range
+        { Dependency.packageMetaComponent = packageMetaComponent.key,
+          Dependency.package = package.key,
+          Dependency.component = component2.key,
+          Dependency.range = range.key
         }
     model2 <- Dependency.Upsert.run dependency2
-    IO.liftIO $ Model.key model2 `Hspec.shouldNotBe` Model.key model1
+    IO.liftIO $ model2.key `Hspec.shouldNotBe` model1.key

--- a/source/library/Monadoc/Action/Exception/NotifySentry.hs
+++ b/source/library/Monadoc/Action/Exception/NotifySentry.hs
@@ -40,8 +40,8 @@ run ::
   App.App ()
 run f exception = Monad.when (shouldNotify exception) $ do
   context <- Reader.ask
-  Monad.forM_ (Config.dsn $ Context.config context) $ \dsn -> do
-    let manager = Context.manager context
+  Monad.forM_ context.config.dsn $ \dsn -> do
+    let manager = context.manager
     event <- IO.liftIO Patrol.Event.new
     environment <- IO.liftIO Environment.getEnvironment
     response <-
@@ -63,7 +63,7 @@ run f exception = Monad.when (shouldNotify exception) $ do
                                 }
                         ]
                     },
-              Patrol.Event.release = Config.sha $ Context.config context,
+              Patrol.Event.release = context.config.sha,
               Patrol.Event.request =
                 Just
                   Patrol.Request.empty

--- a/source/library/Monadoc/Action/HackageIndex/Insert.hs
+++ b/source/library/Monadoc/Action/HackageIndex/Insert.hs
@@ -39,9 +39,9 @@ run = do
   App.Log.debug "inserting hackage index"
   uncompressedSize <- getSize
   context <- Reader.ask
-  request <- Client.parseUrlThrow $ Config.hackage (Context.config context) <> "01-index.tar.gz"
+  request <- Client.parseUrlThrow $ context.config.hackage <> "01-index.tar.gz"
   Control.control $ \runInBase ->
-    Client.withResponse (Client.ensureUserAgent request) (Context.manager context) $ \response -> runInBase $ do
+    Client.withResponse (Client.ensureUserAgent request) context.manager $ \response -> runInBase $ do
       Proxy.Get.logResponse response
       compressedSize <- getContentLength response
       key <- insertBlob compressedSize
@@ -89,12 +89,13 @@ getSize = do
   context <- Reader.ask
   request <-
     Client.parseUrlThrow $
-      Config.hackage (Context.config context) <> "01-index.tar"
+      context.config.hackage <> "01-index.tar"
   response <-
     Traced.wrap
       . IO.liftIO
-      . Client.httpNoBody (Client.ensureUserAgent request) {Client.method = Http.methodHead}
-      $ Context.manager context
+      $ Client.httpNoBody
+        (Client.ensureUserAgent request) {Client.method = Http.methodHead}
+        context.manager
   Proxy.Get.logResponse response
   getContentLength response
 

--- a/source/library/Monadoc/Action/HackageIndex/Prune.hs
+++ b/source/library/Monadoc/Action/HackageIndex/Prune.hs
@@ -11,12 +11,12 @@ import qualified Monadoc.Type.Model as Model
 
 run :: App.App ()
 run = do
-  rows <- App.Sql.query_ "select * from hackageIndex where processedAt is not null order by processedAt desc"
+  rows <- App.Sql.query_ @HackageIndex.Model "select * from hackageIndex where processedAt is not null order by processedAt desc"
   case rows of
     [] -> App.Log.debug "no hackage indexes to prune"
     keep : rest -> do
-      App.Log.debug $ F.sformat ("keeping" F.%+ Key.format) (Model.key keep)
+      App.Log.debug $ F.sformat ("keeping" F.%+ Key.format) keep.key
       Monad.forM_ rest $ \hackageIndex -> do
-        App.Log.debug $ F.sformat ("pruning" F.%+ Key.format) (Model.key hackageIndex)
-        App.Sql.execute "delete from hackageIndex where key = ?" [Model.key hackageIndex]
-        App.Sql.execute "delete from blob where key = ?" [HackageIndex.blob $ Model.value hackageIndex]
+        App.Log.debug $ F.sformat ("pruning" F.%+ Key.format) hackageIndex.key
+        App.Sql.execute "delete from hackageIndex where key = ?" [hackageIndex.key]
+        App.Sql.execute "delete from blob where key = ?" [hackageIndex.value.blob]

--- a/source/library/Monadoc/Action/HackageUser/Upsert.hs
+++ b/source/library/Monadoc/Action/HackageUser/Upsert.hs
@@ -13,7 +13,7 @@ run hackageUser = do
   r1 <-
     App.Sql.query
       "select key from hackageUser where name = ? limit 1"
-      [HackageUser.name hackageUser]
+      [hackageUser.name]
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/HackageUser/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/HackageUser/UpsertSpec.hs
@@ -34,4 +34,4 @@ spec = Hspec.describe "Monadoc.Action.HackageUser.Upsert" $ do
     hackageUser2 <- do
       x <- Test.arbitraryWith $ \y -> y {HackageUser.name = Witch.unsafeFrom @Text.Text "b"}
       HackageUser.Upsert.run x
-    IO.liftIO $ Model.key hackageUser1 `Hspec.shouldNotBe` Model.key hackageUser2
+    IO.liftIO $ hackageUser1.key `Hspec.shouldNotBe` hackageUser2.key

--- a/source/library/Monadoc/Action/Job/Acquire.hs
+++ b/source/library/Monadoc/Action/Job/Acquire.hs
@@ -16,5 +16,5 @@ run = do
       now <- Timestamp.getCurrentTime
       App.Sql.execute
         "update job set startedAt = ?, status = ? where key = ?"
-        (now, Status.Locked, Model.key job)
+        (now, Status.Locked, job.key)
       pure $ Just job

--- a/source/library/Monadoc/Action/Job/EnqueueSpec.hs
+++ b/source/library/Monadoc/Action/Job/EnqueueSpec.hs
@@ -15,8 +15,8 @@ spec = Hspec.describe "Monadoc.Action.Job.Enqueue" $ do
     task <- Test.arbitrary
     model <- Job.Enqueue.run task
     IO.liftIO $ do
-      Model.key model `Hspec.shouldBe` Witch.from @Int 1
-      Job.finishedAt (Model.value model) `Hspec.shouldBe` Nothing
-      Job.startedAt (Model.value model) `Hspec.shouldBe` Nothing
-      Job.status (Model.value model) `Hspec.shouldBe` Status.Queued
-      Job.task (Model.value model) `Hspec.shouldBe` task
+      model.key `Hspec.shouldBe` Witch.from @Int 1
+      model.value.finishedAt `Hspec.shouldBe` Nothing
+      model.value.startedAt `Hspec.shouldBe` Nothing
+      model.value.status `Hspec.shouldBe` Status.Queued
+      model.value.task `Hspec.shouldBe` task

--- a/source/library/Monadoc/Action/Job/Perform.hs
+++ b/source/library/Monadoc/Action/Job/Perform.hs
@@ -17,19 +17,19 @@ run :: Maybe Job.Model -> App.App ()
 run maybeJob = case maybeJob of
   Nothing -> IO.liftIO $ Concurrent.threadDelay 1_000_000
   Just job -> do
-    let task = Job.task $ Model.value job
+    let task = job.value.task
     App.Log.info $
       F.sformat
         ("[worker] starting" F.%+ Key.format F.% ":" F.%+ F.shown)
-        (Model.key job)
+        job.key
         task
     before <- IO.liftIO Clock.getMonotonicTime
     () <- Control.control $ \runInBase ->
-      Async.withAsync (runInBase . Task.Perform.run . Job.task $ Model.value job) Async.wait
+      Async.withAsync (runInBase $ Task.Perform.run job.value.task) Async.wait
     after <- IO.liftIO Clock.getMonotonicTime
     App.Log.info $
       F.sformat
         ("[worker] finished" F.%+ Key.format F.% ":" F.%+ F.shown F.%+ "in" F.%+ F.fixed 3)
-        (Model.key job)
+        job.key
         task
         (after - before)

--- a/source/library/Monadoc/Action/Job/Release.hs
+++ b/source/library/Monadoc/Action/Job/Release.hs
@@ -22,4 +22,4 @@ run maybeJob exitCase = case maybeJob of
           Exception.ExitCaseAbort -> Status.Failed
     App.Sql.execute
       "update job set finishedAt = ?, status = ? where key = ?"
-      (now, status, Model.key job)
+      (now, status, job.key)

--- a/source/library/Monadoc/Action/License/Upsert.hs
+++ b/source/library/Monadoc/Action/License/Upsert.hs
@@ -13,7 +13,7 @@ run license = do
   r1 <-
     App.Sql.query
       "select key from license where spdx = ? limit 1"
-      [License.spdx license]
+      [license.spdx]
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/License/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/License/UpsertSpec.hs
@@ -31,4 +31,4 @@ spec = Hspec.describe "Monadoc.Action.License.Upsert" $ do
     license2 <- Test.arbitraryWith $ \x -> x {License.spdx = Witch.unsafeFrom @String "ISC"}
     model1 <- License.Upsert.run license1
     model2 <- License.Upsert.run license2
-    IO.liftIO $ Model.key model1 `Hspec.shouldNotBe` Model.key model2
+    IO.liftIO $ model1.key `Hspec.shouldNotBe` model2.key

--- a/source/library/Monadoc/Action/Migration/Migrate.hs
+++ b/source/library/Monadoc/Action/Migration/Migrate.hs
@@ -16,8 +16,8 @@ run ::
   Migration.Migration ->
   App.App Migration.Model
 run migration = do
-  let createdAt = Migration.createdAt migration
-      query = Migration.query migration
+  let createdAt = migration.createdAt
+      query = migration.query
   models <- App.Sql.query "select * from migration where createdAt = ? limit 1" [createdAt]
   case models of
     [] -> do
@@ -25,7 +25,7 @@ run migration = do
       App.Sql.execute_ query
       Migration.Insert.run migration
     model : _ -> do
-      let oldQuery = Migration.query $ Model.value model
+      let oldQuery = model.value.query
       Monad.when (oldQuery /= query) $
         Traced.throw
           Mismatch.Mismatch

--- a/source/library/Monadoc/Action/Module/Upsert.hs
+++ b/source/library/Monadoc/Action/Module/Upsert.hs
@@ -13,7 +13,7 @@ run module_ = do
   r1 <-
     App.Sql.query
       "select key from module where name = ? limit 1"
-      [Module.name module_]
+      [module_.name]
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/Module/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Module/UpsertSpec.hs
@@ -30,4 +30,4 @@ spec = Hspec.describe "Monadoc.Action.Module.Upsert" $ do
     model1 <- Module.Upsert.run module1
     module2 <- Test.arbitrary
     model2 <- Module.Upsert.run module2
-    IO.liftIO $ Model.key model1 `Hspec.shouldNotBe` Model.key model2
+    IO.liftIO $ model1.key `Hspec.shouldNotBe` model2.key

--- a/source/library/Monadoc/Action/Package/Upsert.hs
+++ b/source/library/Monadoc/Action/Package/Upsert.hs
@@ -12,7 +12,7 @@ import qualified Monadoc.Type.Model as Model
 run :: Package.Package -> App.App Package.Model
 run package = do
   maybeModel <-
-    Package.Query.getByName $ Package.name package
+    Package.Query.getByName package.name
   case maybeModel of
     Just model -> pure model
     Nothing -> do

--- a/source/library/Monadoc/Action/Package/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Package/UpsertSpec.hs
@@ -33,4 +33,4 @@ spec = Hspec.describe "Monadoc.Action.Package.Upsert" $ do
     package2 <- do
       x <- Test.arbitraryWith $ \y -> y {Package.name = Witch.unsafeFrom @String "b"}
       Package.Upsert.run x
-    IO.liftIO $ Model.key package1 `Hspec.shouldNotBe` Model.key package2
+    IO.liftIO $ package1.key `Hspec.shouldNotBe` package2.key

--- a/source/library/Monadoc/Action/PackageMeta/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/PackageMeta/UpsertSpec.hs
@@ -28,11 +28,11 @@ spec = Hspec.describe "Monadoc.Action.PackageMeta.Upsert" $ do
     packageMeta2 <- makePackageMeta
     model1 <- PackageMeta.Upsert.run packageMeta1
     model2 <- PackageMeta.Upsert.run packageMeta2
-    IO.liftIO $ Model.key model1 `Hspec.shouldNotBe` Model.key model2
+    IO.liftIO $ model1.key `Hspec.shouldNotBe` model2.key
 
   Hspec.it "updates an existing package meta" . Test.run $ do
     model <- Factory.newPackageMeta
-    let packageMeta = (Model.value model) {PackageMeta.hash = Hash.new "updated"}
+    let packageMeta = model.value {PackageMeta.hash = Hash.new "updated"}
     result <- PackageMeta.Upsert.run packageMeta
     IO.liftIO $ result `Hspec.shouldBe` model {Model.value = packageMeta}
 
@@ -43,7 +43,7 @@ makePackageMeta = do
   upload <- Factory.newUpload
   Test.arbitraryWith $ \packageMeta ->
     packageMeta
-      { PackageMeta.cabalVersion = Model.key version,
-        PackageMeta.license = Model.key license,
-        PackageMeta.upload = Model.key upload
+      { PackageMeta.cabalVersion = version.key,
+        PackageMeta.license = license.key,
+        PackageMeta.upload = upload.key
       }

--- a/source/library/Monadoc/Action/PackageMetaComponent/Upsert.hs
+++ b/source/library/Monadoc/Action/PackageMetaComponent/Upsert.hs
@@ -13,7 +13,7 @@ run packageMetaComponent = do
   r1 <-
     App.Sql.query
       "select key from packageMetaComponent where packageMeta = ? and component = ? limit 1"
-      (PackageMetaComponent.packageMeta packageMetaComponent, PackageMetaComponent.component packageMetaComponent)
+      (packageMetaComponent.packageMeta, packageMetaComponent.component)
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/PackageMetaComponent/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/PackageMetaComponent/UpsertSpec.hs
@@ -16,8 +16,8 @@ spec = Hspec.describe "Monadoc.Action.PackageMetaComponent.Upsert" $ do
     component <- Factory.newComponent
     packageMetaComponent <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponent.packageMeta = Model.key packageMeta,
-          PackageMetaComponent.component = Model.key component
+        { PackageMetaComponent.packageMeta = packageMeta.key,
+          PackageMetaComponent.component = component.key
         }
     model <- PackageMetaComponent.Upsert.run packageMetaComponent
     IO.liftIO $
@@ -32,8 +32,8 @@ spec = Hspec.describe "Monadoc.Action.PackageMetaComponent.Upsert" $ do
     component <- Factory.newComponent
     packageMetaComponent <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponent.packageMeta = Model.key packageMeta,
-          PackageMetaComponent.component = Model.key component
+        { PackageMetaComponent.packageMeta = packageMeta.key,
+          PackageMetaComponent.component = component.key
         }
     old <- PackageMetaComponent.Upsert.run packageMetaComponent
     new <- PackageMetaComponent.Upsert.run packageMetaComponent
@@ -44,15 +44,15 @@ spec = Hspec.describe "Monadoc.Action.PackageMetaComponent.Upsert" $ do
     component1 <- Factory.newComponent
     packageMetaComponent1 <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponent.packageMeta = Model.key packageMeta,
-          PackageMetaComponent.component = Model.key component1
+        { PackageMetaComponent.packageMeta = packageMeta.key,
+          PackageMetaComponent.component = component1.key
         }
     model1 <- PackageMetaComponent.Upsert.run packageMetaComponent1
     component2 <- Factory.newComponent
     packageMetaComponent2 <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponent.packageMeta = Model.key packageMeta,
-          PackageMetaComponent.component = Model.key component2
+        { PackageMetaComponent.packageMeta = packageMeta.key,
+          PackageMetaComponent.component = component2.key
         }
     model2 <- PackageMetaComponent.Upsert.run packageMetaComponent2
-    IO.liftIO $ Model.key model1 `Hspec.shouldNotBe` Model.key model2
+    IO.liftIO $ model1.key `Hspec.shouldNotBe` model2.key

--- a/source/library/Monadoc/Action/PackageMetaComponentModule/Upsert.hs
+++ b/source/library/Monadoc/Action/PackageMetaComponentModule/Upsert.hs
@@ -13,7 +13,7 @@ run packageMetaComponentModule = do
   r1 <-
     App.Sql.query
       "select key from packageMetaComponentModule where packageMetaComponent = ? and module = ? limit 1"
-      (PackageMetaComponentModule.packageMetaComponent packageMetaComponentModule, PackageMetaComponentModule.module_ packageMetaComponentModule)
+      (packageMetaComponentModule.packageMetaComponent, packageMetaComponentModule.module_)
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/PackageMetaComponentModule/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/PackageMetaComponentModule/UpsertSpec.hs
@@ -16,8 +16,8 @@ spec = Hspec.describe "Monadoc.Action.PackageMetaComponentModule.Upsert" $ do
     module_ <- Factory.newModule
     packageMetaComponentModule <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponentModule.packageMetaComponent = Model.key packageMetaComponent,
-          PackageMetaComponentModule.module_ = Model.key module_
+        { PackageMetaComponentModule.packageMetaComponent = packageMetaComponent.key,
+          PackageMetaComponentModule.module_ = module_.key
         }
     actual <- PackageMetaComponentModule.Upsert.run packageMetaComponentModule
     let expected =
@@ -32,8 +32,8 @@ spec = Hspec.describe "Monadoc.Action.PackageMetaComponentModule.Upsert" $ do
     module_ <- Factory.newModule
     packageMetaComponentModule <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponentModule.packageMetaComponent = Model.key packageMetaComponent,
-          PackageMetaComponentModule.module_ = Model.key module_
+        { PackageMetaComponentModule.packageMetaComponent = packageMetaComponent.key,
+          PackageMetaComponentModule.module_ = module_.key
         }
     old <- PackageMetaComponentModule.Upsert.run packageMetaComponentModule
     new <- PackageMetaComponentModule.Upsert.run packageMetaComponentModule
@@ -44,15 +44,15 @@ spec = Hspec.describe "Monadoc.Action.PackageMetaComponentModule.Upsert" $ do
     module1 <- Factory.newModule
     packageMetaComponentModule1 <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponentModule.packageMetaComponent = Model.key packageMetaComponent,
-          PackageMetaComponentModule.module_ = Model.key module1
+        { PackageMetaComponentModule.packageMetaComponent = packageMetaComponent.key,
+          PackageMetaComponentModule.module_ = module1.key
         }
     model1 <- PackageMetaComponentModule.Upsert.run packageMetaComponentModule1
     module2 <- Factory.newModule
     packageMetaComponentModule2 <- Test.arbitraryWith $ \x ->
       x
-        { PackageMetaComponentModule.packageMetaComponent = Model.key packageMetaComponent,
-          PackageMetaComponentModule.module_ = Model.key module2
+        { PackageMetaComponentModule.packageMetaComponent = packageMetaComponent.key,
+          PackageMetaComponentModule.module_ = module2.key
         }
     model2 <- PackageMetaComponentModule.Upsert.run packageMetaComponentModule2
-    IO.liftIO $ Model.key model1 `Hspec.shouldNotBe` Model.key model2
+    IO.liftIO $ model1.key `Hspec.shouldNotBe` model2.key

--- a/source/library/Monadoc/Action/Preference/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Preference/UpsertSpec.hs
@@ -26,8 +26,8 @@ spec = Hspec.describe "Monadoc.Action.Preference.Upsert" $ do
       Range.Upsert.run x
     let preference =
           Preference.Preference
-            { Preference.package = Model.key package,
-              Preference.range = Model.key range
+            { Preference.package = package.key,
+              Preference.range = range.key
             }
     model <- Preference.Upsert.run preference
     IO.liftIO $
@@ -41,13 +41,13 @@ spec = Hspec.describe "Monadoc.Action.Preference.Upsert" $ do
     old <- upsertPreference (Witch.unsafeFrom @String "a") (Witch.unsafeFrom @String ">1")
     new <- upsertPreference (Witch.unsafeFrom @String "a") (Witch.unsafeFrom @String ">2")
     IO.liftIO $ do
-      Model.key new `Hspec.shouldBe` Model.key old
-      Preference.range (Model.value new) `Hspec.shouldNotBe` Preference.range (Model.value old)
+      new.key `Hspec.shouldBe` old.key
+      new.value.range `Hspec.shouldNotBe` old.value.range
 
   Hspec.it "inserts two preferences" . Test.run $ do
     preference1 <- upsertPreference (Witch.unsafeFrom @String "a") (Witch.unsafeFrom @String ">1")
     preference2 <- upsertPreference (Witch.unsafeFrom @String "b") (Witch.unsafeFrom @String ">1")
-    IO.liftIO $ Model.key preference1 `Hspec.shouldNotBe` Model.key preference2
+    IO.liftIO $ preference1.key `Hspec.shouldNotBe` preference2.key
 
 upsertPreference ::
   PackageName.PackageName ->
@@ -58,6 +58,6 @@ upsertPreference packageName constraint = do
   range <- Range.Upsert.run Range.Range {Range.constraint = constraint}
   Preference.Upsert.run
     Preference.Preference
-      { Preference.package = Model.key package,
-        Preference.range = Model.key range
+      { Preference.package = package.key,
+        Preference.range = range.key
       }

--- a/source/library/Monadoc/Action/Range/Upsert.hs
+++ b/source/library/Monadoc/Action/Range/Upsert.hs
@@ -13,7 +13,7 @@ run range = do
   r1 <-
     App.Sql.query
       "select key from range where \"constraint\" = ? limit 1"
-      [Range.constraint range]
+      [range.constraint]
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/Range/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Range/UpsertSpec.hs
@@ -30,4 +30,4 @@ spec = Hspec.describe "Monadoc.Action.Range.Upsert" $ do
     range2 <- Test.arbitrary
     model1 <- Range.Upsert.run range1
     model2 <- Range.Upsert.run range2
-    IO.liftIO $ Model.key model1 `Hspec.shouldNotBe` Model.key model2
+    IO.liftIO $ model1.key `Hspec.shouldNotBe` model2.key

--- a/source/library/Monadoc/Action/Upload/Process.hs
+++ b/source/library/Monadoc/Action/Upload/Process.hs
@@ -233,10 +233,10 @@ salt :: ByteString.ByteString
 salt = "2022-08-08"
 
 hashBlob :: Blob.Model -> Hash.Hash
-hashBlob = Hash.new . mappend salt . Witch.from . (.hash) . (.value)
+hashBlob = Hash.new . mappend salt . Witch.from . (.value.hash)
 
 hashPackageMeta :: PackageMeta.Model -> Hash.Hash
-hashPackageMeta = (.hash) . (.value)
+hashPackageMeta = (.value.hash)
 
 shortTextToMaybeText :: Cabal.ShortText -> Maybe Text.Text
 shortTextToMaybeText shortText =

--- a/source/library/Monadoc/Action/Upload/Upsert.hs
+++ b/source/library/Monadoc/Action/Upload/Upsert.hs
@@ -13,7 +13,7 @@ run upload = do
   r1 <-
     App.Sql.query
       "select key from upload where package = ? and version = ? and revision = ? limit 1"
-      (Upload.package upload, Upload.version upload, Upload.revision upload)
+      (upload.package, upload.version, upload.revision)
   key <- case r1 of
     Sql.Only key : _ -> pure key
     [] -> do

--- a/source/library/Monadoc/Action/Upload/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Upload/UpsertSpec.hs
@@ -29,10 +29,10 @@ spec = Hspec.describe "Monadoc.Action.Upload.Upsert" $ do
       Version.Upsert.run x
     upload <- Test.arbitraryWith $ \x ->
       x
-        { Upload.blob = Model.key blob,
-          Upload.package = Model.key package,
-          Upload.uploadedBy = Model.key hackageUser,
-          Upload.version = Model.key version
+        { Upload.blob = blob.key,
+          Upload.package = package.key,
+          Upload.uploadedBy = hackageUser.key,
+          Upload.version = version.key
         }
     model <- Upload.Upsert.run upload
     IO.liftIO $
@@ -57,10 +57,10 @@ spec = Hspec.describe "Monadoc.Action.Upload.Upsert" $ do
       Version.Upsert.run x
     upload <- Test.arbitraryWith $ \x ->
       x
-        { Upload.blob = Model.key blob,
-          Upload.package = Model.key package,
-          Upload.uploadedBy = Model.key hackageUser,
-          Upload.version = Model.key version
+        { Upload.blob = blob.key,
+          Upload.package = package.key,
+          Upload.uploadedBy = hackageUser.key,
+          Upload.version = version.key
         }
     old <- Upload.Upsert.run upload
     new <- Upload.Upsert.run upload
@@ -81,11 +81,11 @@ spec = Hspec.describe "Monadoc.Action.Upload.Upsert" $ do
       Version.Upsert.run x
     upload <- Test.arbitraryWith $ \x ->
       x
-        { Upload.blob = Model.key blob,
-          Upload.package = Model.key package,
-          Upload.uploadedBy = Model.key hackageUser,
-          Upload.version = Model.key version
+        { Upload.blob = blob.key,
+          Upload.package = package.key,
+          Upload.uploadedBy = hackageUser.key,
+          Upload.version = version.key
         }
     model1 <- Upload.Upsert.run upload {Upload.revision = Witch.from @Word 1}
     model2 <- Upload.Upsert.run upload {Upload.revision = Witch.from @Word 2}
-    IO.liftIO $ Model.key model1 `Hspec.shouldNotBe` Model.key model2
+    IO.liftIO $ model1.key `Hspec.shouldNotBe` model2.key

--- a/source/library/Monadoc/Action/Version/Upsert.hs
+++ b/source/library/Monadoc/Action/Version/Upsert.hs
@@ -11,7 +11,7 @@ import qualified Monadoc.Type.Model as Model
 
 run :: Version.Version -> App.App Version.Model
 run version = do
-  maybeModel <- Version.Query.getByNumber $ Version.number version
+  maybeModel <- Version.Query.getByNumber version.number
   case maybeModel of
     Just model -> pure model
     Nothing -> do

--- a/source/library/Monadoc/Action/Version/UpsertSpec.hs
+++ b/source/library/Monadoc/Action/Version/UpsertSpec.hs
@@ -33,4 +33,4 @@ spec = Hspec.describe "Monadoc.Action.Version.Upsert" $ do
     version2 <- do
       x <- Test.arbitraryWith $ \y -> y {Version.number = Witch.unsafeFrom @String "2"}
       Version.Upsert.run x
-    IO.liftIO $ Model.key version1 `Hspec.shouldNotBe` Model.key version2
+    IO.liftIO $ version1.key `Hspec.shouldNotBe` version2.key

--- a/source/library/Monadoc/Constant/Migration.hs
+++ b/source/library/Monadoc/Constant/Migration.hs
@@ -22,7 +22,7 @@ import qualified Monadoc.Model.Version as Version
 
 all :: [Migration.Migration]
 all =
-  List.sortOn Migration.createdAt $
+  List.sortOn (.createdAt) $
     mconcat
       [ Blob.migrations,
         Component.migrations,

--- a/source/library/Monadoc/Factory.hs
+++ b/source/library/Monadoc/Factory.hs
@@ -55,7 +55,7 @@ newDependency = do
   package <- newPackage
   component <- newComponent
   range <- newRange
-  newDependencyWith (Model.key packageMetaComponent) (Model.key package) (Model.key component) (Model.key range)
+  newDependencyWith packageMetaComponent.key package.key component.key range.key
 
 newDependencyWith ::
   PackageMetaComponent.Key ->
@@ -98,7 +98,7 @@ newPackageMeta = do
   version <- newVersion
   license <- newLicense
   upload <- newUpload
-  newPackageMetaWith (Model.key version) (Model.key license) (Model.key upload)
+  newPackageMetaWith version.key license.key upload.key
 
 newPackageMetaWith ::
   Version.Key ->
@@ -118,7 +118,7 @@ newPackageMetaComponent :: App.App PackageMetaComponent.Model
 newPackageMetaComponent = do
   packageMeta <- newPackageMeta
   component <- newComponent
-  newPackageMetaComponentWith (Model.key packageMeta) (Model.key component)
+  newPackageMetaComponentWith packageMeta.key component.key
 
 newPackageMetaComponentWith ::
   PackageMeta.Key ->
@@ -136,7 +136,7 @@ newPackageMetaComponentModule :: App.App PackageMetaComponentModule.Model
 newPackageMetaComponentModule = do
   packageMetaComponent <- newPackageMetaComponent
   module_ <- newModule
-  newPackageMetaComponentModuleWith (Model.key packageMetaComponent) (Model.key module_)
+  newPackageMetaComponentModuleWith packageMetaComponent.key module_.key
 
 newPackageMetaComponentModuleWith ::
   PackageMetaComponent.Key ->
@@ -154,7 +154,7 @@ newPreference :: App.App Preference.Model
 newPreference = do
   package <- newPackage
   range <- newRange
-  newPreferenceWith (Model.key package) (Model.key range)
+  newPreferenceWith package.key range.key
 
 newPreferenceWith ::
   Package.Key ->
@@ -179,7 +179,7 @@ newUpload = do
   package <- newPackage
   hackageUser <- newHackageUser
   version <- newVersion
-  newUploadWith (Model.key blob) (Model.key package) (Model.key hackageUser) (Model.key version)
+  newUploadWith blob.key package.key hackageUser.key version.key
 
 newUploadWith ::
   Blob.Key ->

--- a/source/library/Monadoc/Handler/Home/Get.hs
+++ b/source/library/Monadoc/Handler/Home/Get.hs
@@ -30,7 +30,7 @@ handler _ respond = do
       \ order by upload.uploadedAt desc \
       \ limit 64"
   let eTag = Common.makeETag $ case rows of
-        (upload Sql.:. _) : _ -> Just . Upload.uploadedAt $ Model.value upload
+        (upload Sql.:. _) : _ -> Just upload.value.uploadedAt
         _ -> Nothing
       breadcrumbs =
         [ Breadcrumb.Breadcrumb {Breadcrumb.label = "Home", Breadcrumb.route = Nothing}

--- a/source/library/Monadoc/Handler/Manifest/Get.hs
+++ b/source/library/Monadoc/Handler/Manifest/Get.hs
@@ -35,7 +35,7 @@ makeManifest context =
   Manifest.Manifest
     { Manifest.schema = "https://json.schemastore.org/web-manifest-combined.json",
       Manifest.name = "Monadoc",
-      Manifest.startUrl = Config.base $ Context.config context,
+      Manifest.startUrl = context.config.base,
       Manifest.display = "minimal-ui",
       Manifest.icons =
         [ Icon.Icon

--- a/source/library/Monadoc/Handler/Package/Get.hs
+++ b/source/library/Monadoc/Handler/Package/Get.hs
@@ -36,7 +36,7 @@ handler packageName _ respond = do
         \ on packageMeta.upload = upload.key \
         \ where upload.package = ? \
         \ order by upload.uploadedAt desc"
-        [Model.key package]
+        [package.key]
     NotFound.fromMaybe $ NonEmpty.nonEmpty xs
   hackageUsers <-
     App.Sql.query
@@ -44,9 +44,9 @@ handler packageName _ respond = do
       \ from hackageUser \
       \ where key in (select distinct uploadedBy from upload where upload.package = ?) \
       \ order by name collate nocase asc"
-      [Model.key package]
+      [package.key]
   let (latest Sql.:. _) NonEmpty.:| _ = rows
-      eTag = Common.makeETag . Just . Upload.uploadedAt $ Model.value latest
+      eTag = Common.makeETag $ Just latest.value.uploadedAt
       breadcrumbs =
         [ Breadcrumb.Breadcrumb {Breadcrumb.label = "Home", Breadcrumb.route = Just Route.Home},
           Breadcrumb.Breadcrumb {Breadcrumb.label = Witch.into @Text.Text packageName, Breadcrumb.route = Nothing}

--- a/source/library/Monadoc/Handler/Proxy/Get.hs
+++ b/source/library/Monadoc/Handler/Proxy/Get.hs
@@ -43,7 +43,7 @@ handler context actual url request respond = do
   Control.control $ \runInBase ->
     Client.withResponse
       (forwardHeaders request . Client.ensureUserAgent $ Client.setRequestCheckStatus proxy)
-      (Context.manager context)
+      context.manager
       $ \response -> runInBase $ do
         logResponse response
         let headers = filter (flip Set.member headersToKeep . fst) $ Client.responseHeaders response
@@ -84,7 +84,7 @@ makeHash :: Context.Context -> Url.Url -> Hash.Hash
 makeHash context =
   Hash.new
     . Witch.via @(Witch.UTF_8 ByteString.ByteString)
-    . mappend (Config.salt $ Context.config context)
+    . mappend context.config.salt
     . Witch.from
 
 logResponse :: Client.Response a -> App.App ()

--- a/source/library/Monadoc/Handler/User/Get.hs
+++ b/source/library/Monadoc/Handler/User/Get.hs
@@ -34,15 +34,15 @@ handler hackageUserName _ respond = do
       \ where upload.uploadedBy = ? \
       \ order by upload.uploadedAt desc \
       \ limit 64"
-      [Model.key hackageUser]
+      [hackageUser.key]
   let eTag = Common.makeETag $ case rows of
-        (upload Sql.:. _) : _ -> Just . Upload.uploadedAt $ Model.value upload
+        (upload Sql.:. _) : _ -> Just upload.value.uploadedAt
         _ -> Nothing
       breadcrumbs =
         [ Breadcrumb.Breadcrumb {Breadcrumb.label = "Home", Breadcrumb.route = Just Route.Home},
           Breadcrumb.Breadcrumb {Breadcrumb.label = Witch.into @Text.Text hackageUserName, Breadcrumb.route = Nothing}
         ]
-  packages <- App.Sql.query "select * from package where key in ( select distinct package from upload where uploadedBy = ? ) order by name collate nocase asc" [Model.key hackageUser]
+  packages <- App.Sql.query "select * from package where key in ( select distinct package from upload where uploadedBy = ? ) order by name collate nocase asc" [hackageUser.key]
   respond
     . Common.htmlResponse
       Http.ok200

--- a/source/library/Monadoc/Main/Executable.hs
+++ b/source/library/Monadoc/Main/Executable.hs
@@ -57,4 +57,4 @@ stop :: App.App ()
 stop = do
   App.Log.info "shutting down"
   context <- Reader.ask
-  IO.liftIO . Pool.destroyAllResources $ Context.pool context
+  IO.liftIO $ Pool.destroyAllResources context.pool

--- a/source/library/Monadoc/Middleware/HandleExceptions.hs
+++ b/source/library/Monadoc/Middleware/HandleExceptions.hs
@@ -61,7 +61,7 @@ withRequest context request event =
   let oldRequest = Maybe.fromMaybe Patrol.Request.empty $ Patrol.Event.request event
       newRequest =
         oldRequest
-          { Patrol.Request.env = Map.insert "MONADOC_REQUEST_ID" (Aeson.toJSON . Vault.lookup (Context.key context) $ Wai.vault request) $ Patrol.Request.env oldRequest,
+          { Patrol.Request.env = Map.insert "MONADOC_REQUEST_ID" (Aeson.toJSON . Vault.lookup context.key $ Wai.vault request) $ Patrol.Request.env oldRequest,
             Patrol.Request.headers =
               Map.fromList
                 . fmap (Bifunctor.bimap (fromUtf8 . CI.foldedCase) fromUtf8)
@@ -73,7 +73,7 @@ withRequest context request event =
                 . Http.parseQueryText
                 $ Wai.rawQueryString request,
             Patrol.Request.url =
-              (Text.pack . Config.base $ Context.config context)
+              (Text.pack context.config.base)
                 <> (Text.drop 1 . fromUtf8 $ Wai.rawPathInfo request)
           }
    in event {Patrol.Event.request = Just newRequest}

--- a/source/library/Monadoc/Middleware/LogResponses.hs
+++ b/source/library/Monadoc/Middleware/LogResponses.hs
@@ -17,7 +17,7 @@ middleware context handle request respond = do
   before <- Clock.getMonotonicTime
   handle request $ \response -> do
     after <- Clock.getMonotonicTime
-    let requestId = Maybe.fromMaybe RequestId.zero . Vault.lookup (Context.key context) $ Wai.vault request
+    let requestId = Maybe.fromMaybe RequestId.zero . Vault.lookup context.key $ Wai.vault request
     App.run context . App.Log.info $
       F.sformat
         ("[server]" F.%+ RequestId.format F.%+ F.int F.%+ F.stext F.%+ F.stext F.% F.stext F.%+ F.fixed 3)

--- a/source/library/Monadoc/Model/Blob.hs
+++ b/source/library/Monadoc/Model/Blob.hs
@@ -29,9 +29,9 @@ instance Sql.FromRow Blob where
 
 instance Sql.ToRow Blob where
   toRow blob =
-    [ Sql.toField $ size blob,
-      Sql.toField $ hash blob,
-      Sql.toField $ contents blob
+    [ Sql.toField blob.size,
+      Sql.toField blob.hash,
+      Sql.toField blob.contents
     ]
 
 instance QuickCheck.Arbitrary Blob where
@@ -49,9 +49,9 @@ migrations =
   ]
 
 new :: ByteString.ByteString -> Blob
-new byteString =
+new contents =
   Blob
-    { contents = byteString,
-      hash = Hash.new byteString,
-      size = ByteString.length byteString
+    { contents = contents,
+      hash = Hash.new contents,
+      size = ByteString.length contents
     }

--- a/source/library/Monadoc/Model/Component.hs
+++ b/source/library/Monadoc/Model/Component.hs
@@ -29,8 +29,8 @@ instance Sql.FromRow Component where
 
 instance Sql.ToRow Component where
   toRow packageMeta =
-    [ Sql.toField $ type_ packageMeta,
-      Sql.toField $ name packageMeta
+    [ Sql.toField packageMeta.type_,
+      Sql.toField packageMeta.name
     ]
 
 instance QuickCheck.Arbitrary Component where

--- a/source/library/Monadoc/Model/CronEntry.hs
+++ b/source/library/Monadoc/Model/CronEntry.hs
@@ -33,10 +33,10 @@ instance Sql.FromRow CronEntry where
 
 instance Sql.ToRow CronEntry where
   toRow cronEntry =
-    [ Sql.toField $ guid cronEntry,
-      Sql.toField $ runAt cronEntry,
-      Sql.toField $ schedule cronEntry,
-      Sql.toField $ task cronEntry
+    [ Sql.toField cronEntry.guid,
+      Sql.toField cronEntry.runAt,
+      Sql.toField cronEntry.schedule,
+      Sql.toField cronEntry.task
     ]
 
 instance QuickCheck.Arbitrary CronEntry where

--- a/source/library/Monadoc/Model/Dependency.hs
+++ b/source/library/Monadoc/Model/Dependency.hs
@@ -33,10 +33,10 @@ instance Sql.FromRow Dependency where
 
 instance Sql.ToRow Dependency where
   toRow packageMeta =
-    [ Sql.toField $ packageMetaComponent packageMeta,
-      Sql.toField $ package packageMeta,
-      Sql.toField $ component packageMeta,
-      Sql.toField $ range packageMeta
+    [ Sql.toField packageMeta.packageMetaComponent,
+      Sql.toField packageMeta.package,
+      Sql.toField packageMeta.component,
+      Sql.toField packageMeta.range
     ]
 
 instance QuickCheck.Arbitrary Dependency where

--- a/source/library/Monadoc/Model/HackageIndex.hs
+++ b/source/library/Monadoc/Model/HackageIndex.hs
@@ -31,10 +31,10 @@ instance Sql.FromRow HackageIndex where
 
 instance Sql.ToRow HackageIndex where
   toRow hackageIndex =
-    [ Sql.toField $ blob hackageIndex,
-      Sql.toField $ createdAt hackageIndex,
-      Sql.toField $ processedAt hackageIndex,
-      Sql.toField $ size hackageIndex
+    [ Sql.toField hackageIndex.blob,
+      Sql.toField hackageIndex.createdAt,
+      Sql.toField hackageIndex.processedAt,
+      Sql.toField hackageIndex.size
     ]
 
 instance QuickCheck.Arbitrary HackageIndex where

--- a/source/library/Monadoc/Model/HackageUser.hs
+++ b/source/library/Monadoc/Model/HackageUser.hs
@@ -24,7 +24,7 @@ instance Sql.FromRow HackageUser where
 
 instance Sql.ToRow HackageUser where
   toRow hackageUser =
-    [ Sql.toField $ name hackageUser
+    [ Sql.toField hackageUser.name
     ]
 
 instance QuickCheck.Arbitrary HackageUser where

--- a/source/library/Monadoc/Model/Job.hs
+++ b/source/library/Monadoc/Model/Job.hs
@@ -34,11 +34,11 @@ instance Sql.FromRow Job where
 
 instance Sql.ToRow Job where
   toRow job =
-    [ Sql.toField $ createdAt job,
-      Sql.toField $ finishedAt job,
-      Sql.toField $ startedAt job,
-      Sql.toField $ status job,
-      Sql.toField $ task job
+    [ Sql.toField job.createdAt,
+      Sql.toField job.finishedAt,
+      Sql.toField job.startedAt,
+      Sql.toField job.status,
+      Sql.toField job.task
     ]
 
 instance QuickCheck.Arbitrary Job where

--- a/source/library/Monadoc/Model/License.hs
+++ b/source/library/Monadoc/Model/License.hs
@@ -24,7 +24,7 @@ instance Sql.FromRow License where
 
 instance Sql.ToRow License where
   toRow license =
-    [ Sql.toField $ spdx license
+    [ Sql.toField license.spdx
     ]
 
 instance QuickCheck.Arbitrary License where

--- a/source/library/Monadoc/Model/Migration.hs
+++ b/source/library/Monadoc/Model/Migration.hs
@@ -30,8 +30,8 @@ instance Sql.FromRow Migration where
 
 instance Sql.ToRow Migration where
   toRow migration =
-    [ Sql.toField $ createdAt migration,
-      Sql.toField $ query migration
+    [ Sql.toField migration.createdAt,
+      Sql.toField migration.query
     ]
 
 instance QuickCheck.Arbitrary Migration where

--- a/source/library/Monadoc/Model/Module.hs
+++ b/source/library/Monadoc/Model/Module.hs
@@ -24,7 +24,7 @@ instance Sql.FromRow Module where
 
 instance Sql.ToRow Module where
   toRow package =
-    [ Sql.toField $ name package
+    [ Sql.toField package.name
     ]
 
 instance QuickCheck.Arbitrary Module where

--- a/source/library/Monadoc/Model/Package.hs
+++ b/source/library/Monadoc/Model/Package.hs
@@ -24,7 +24,7 @@ instance Sql.FromRow Package where
 
 instance Sql.ToRow Package where
   toRow package =
-    [ Sql.toField $ name package
+    [ Sql.toField package.name
     ]
 
 instance QuickCheck.Arbitrary Package where

--- a/source/library/Monadoc/Model/PackageMeta.hs
+++ b/source/library/Monadoc/Model/PackageMeta.hs
@@ -102,21 +102,21 @@ instance Sql.FromRow PackageMeta where
 
 instance Sql.ToRow PackageMeta where
   toRow packageMeta =
-    [ Sql.toField $ buildType packageMeta,
-      Sql.toField $ cabalVersion packageMeta,
-      Sql.toField $ hash packageMeta,
-      Sql.toField $ license packageMeta,
-      Sql.toField $ upload packageMeta,
-      Sql.toField $ author packageMeta,
-      Sql.toField $ bugReports packageMeta,
-      Sql.toField $ category packageMeta,
-      Sql.toField $ copyright packageMeta,
-      Sql.toField $ description packageMeta,
-      Sql.toField $ homepage packageMeta,
-      Sql.toField $ maintainer packageMeta,
-      Sql.toField $ pkgUrl packageMeta,
-      Sql.toField $ stability packageMeta,
-      Sql.toField $ synopsis packageMeta
+    [ Sql.toField packageMeta.buildType,
+      Sql.toField packageMeta.cabalVersion,
+      Sql.toField packageMeta.hash,
+      Sql.toField packageMeta.license,
+      Sql.toField packageMeta.upload,
+      Sql.toField packageMeta.author,
+      Sql.toField packageMeta.bugReports,
+      Sql.toField packageMeta.category,
+      Sql.toField packageMeta.copyright,
+      Sql.toField packageMeta.description,
+      Sql.toField packageMeta.homepage,
+      Sql.toField packageMeta.maintainer,
+      Sql.toField packageMeta.pkgUrl,
+      Sql.toField packageMeta.stability,
+      Sql.toField packageMeta.synopsis
     ]
 
 instance QuickCheck.Arbitrary PackageMeta where

--- a/source/library/Monadoc/Model/PackageMetaComponent.hs
+++ b/source/library/Monadoc/Model/PackageMetaComponent.hs
@@ -27,8 +27,8 @@ instance Sql.FromRow PackageMetaComponent where
 
 instance Sql.ToRow PackageMetaComponent where
   toRow cronEntry =
-    [ Sql.toField $ packageMeta cronEntry,
-      Sql.toField $ component cronEntry
+    [ Sql.toField cronEntry.packageMeta,
+      Sql.toField cronEntry.component
     ]
 
 instance QuickCheck.Arbitrary PackageMetaComponent where

--- a/source/library/Monadoc/Model/PackageMetaComponentModule.hs
+++ b/source/library/Monadoc/Model/PackageMetaComponentModule.hs
@@ -27,8 +27,8 @@ instance Sql.FromRow PackageMetaComponentModule where
 
 instance Sql.ToRow PackageMetaComponentModule where
   toRow cronEntry =
-    [ Sql.toField $ packageMetaComponent cronEntry,
-      Sql.toField $ module_ cronEntry
+    [ Sql.toField cronEntry.packageMetaComponent,
+      Sql.toField cronEntry.module_
     ]
 
 instance QuickCheck.Arbitrary PackageMetaComponentModule where

--- a/source/library/Monadoc/Model/Preference.hs
+++ b/source/library/Monadoc/Model/Preference.hs
@@ -27,8 +27,8 @@ instance Sql.FromRow Preference where
 
 instance Sql.ToRow Preference where
   toRow preference =
-    [ Sql.toField $ package preference,
-      Sql.toField $ range preference
+    [ Sql.toField preference.package,
+      Sql.toField preference.range
     ]
 
 instance QuickCheck.Arbitrary Preference where

--- a/source/library/Monadoc/Model/Range.hs
+++ b/source/library/Monadoc/Model/Range.hs
@@ -24,7 +24,7 @@ instance Sql.FromRow Range where
 
 instance Sql.ToRow Range where
   toRow version =
-    [ Sql.toField $ constraint version
+    [ Sql.toField version.constraint
     ]
 
 instance QuickCheck.Arbitrary Range where

--- a/source/library/Monadoc/Model/Upload.hs
+++ b/source/library/Monadoc/Model/Upload.hs
@@ -43,14 +43,14 @@ instance Sql.FromRow Upload where
 
 instance Sql.ToRow Upload where
   toRow upload =
-    [ Sql.toField $ blob upload,
-      Sql.toField $ package upload,
-      Sql.toField $ revision upload,
-      Sql.toField $ uploadedAt upload,
-      Sql.toField $ uploadedBy upload,
-      Sql.toField $ version upload,
-      Sql.toField $ isPreferred upload,
-      Sql.toField $ isLatest upload
+    [ Sql.toField upload.blob,
+      Sql.toField upload.package,
+      Sql.toField upload.revision,
+      Sql.toField upload.uploadedAt,
+      Sql.toField upload.uploadedBy,
+      Sql.toField upload.version,
+      Sql.toField upload.isPreferred,
+      Sql.toField upload.isLatest
     ]
 
 instance QuickCheck.Arbitrary Upload where

--- a/source/library/Monadoc/Model/Version.hs
+++ b/source/library/Monadoc/Model/Version.hs
@@ -24,7 +24,7 @@ instance Sql.FromRow Version where
 
 instance Sql.ToRow Version where
   toRow version =
-    [ Sql.toField $ number version
+    [ Sql.toField version.number
     ]
 
 instance QuickCheck.Arbitrary Version where

--- a/source/library/Monadoc/Query/BlobSpec.hs
+++ b/source/library/Monadoc/Query/BlobSpec.hs
@@ -13,7 +13,7 @@ spec = Hspec.describe "Monadoc.Query.Blob" $ do
   Hspec.describe "getByHash" $ do
     Hspec.it "works" . Test.run $ do
       blob <- Factory.newBlob
-      result <- Blob.Query.getByHash . Blob.hash $ Model.value blob
+      result <- Blob.Query.getByHash blob.value.hash
       IO.liftIO $ result `Hspec.shouldBe` Just blob
 
     Hspec.it "returns nothing when the hash doesn't exist" . Test.run $ do

--- a/source/library/Monadoc/Query/CronEntrySpec.hs
+++ b/source/library/Monadoc/Query/CronEntrySpec.hs
@@ -27,7 +27,7 @@ spec = Hspec.describe "Monadoc.Query.CronEntry" $ do
   Hspec.describe "getByKey" $ do
     Hspec.it "works" . Test.run $ do
       cronEntry <- Factory.newCronEntry
-      result <- CronEntry.Query.getByKey $ Model.key cronEntry
+      result <- CronEntry.Query.getByKey cronEntry.key
       IO.liftIO $ result `Hspec.shouldBe` Just cronEntry
 
     Hspec.it "returns nothing when the key doesn't exist" . Test.run $ do

--- a/source/library/Monadoc/Query/PackageSpec.hs
+++ b/source/library/Monadoc/Query/PackageSpec.hs
@@ -13,7 +13,7 @@ spec = Hspec.describe "Monadoc.Query.Package" $ do
   Hspec.describe "getByName" $ do
     Hspec.it "works" . Test.run $ do
       package <- Factory.newPackage
-      result <- Package.Query.getByName . Package.name $ Model.value package
+      result <- Package.Query.getByName package.value.name
       IO.liftIO $ result `Hspec.shouldBe` Just package
 
     Hspec.it "returns nothing when the name doesn't exist" . Test.run $ do
@@ -29,4 +29,4 @@ spec = Hspec.describe "Monadoc.Query.Package" $ do
     Hspec.it "works with a package" . Test.run $ do
       package <- Factory.newPackage
       result <- Package.Query.getKeys
-      IO.liftIO $ result `Hspec.shouldBe` [Model.key package]
+      IO.liftIO $ result `Hspec.shouldBe` [package.key]

--- a/source/library/Monadoc/Query/VersionSpec.hs
+++ b/source/library/Monadoc/Query/VersionSpec.hs
@@ -13,7 +13,7 @@ spec = Hspec.describe "Monadoc.Query.Version" $ do
   Hspec.describe "getByNumber" $ do
     Hspec.it "works" . Test.run $ do
       version <- Factory.newVersion
-      result <- Version.Query.getByNumber . Version.number $ Model.value version
+      result <- Version.Query.getByNumber version.value.number
       IO.liftIO $ result `Hspec.shouldBe` Just version
 
     Hspec.it "returns nothing when the number doesn't exist" . Test.run $ do

--- a/source/library/Monadoc/Server/Main.hs
+++ b/source/library/Monadoc/Server/Main.hs
@@ -25,19 +25,19 @@ server = do
 
 getSettings :: Context.Context -> Warp.Settings
 getSettings context =
-  let config = Context.config context
+  let config = context.config
    in Warp.setBeforeMainLoop (beforeMainLoop context)
-        . Warp.setHost (Config.host config)
+        . Warp.setHost config.host
         . Warp.setOnException (HandleExceptions.onException context)
         . Warp.setOnExceptionResponse (HandleExceptions.onExceptionResponse context)
-        . Warp.setPort (Witch.into @Int $ Config.port config)
+        . Warp.setPort (Witch.into @Int config.port)
         $ Warp.setServerName ByteString.empty Warp.defaultSettings
 
 beforeMainLoop :: Context.Context -> IO ()
 beforeMainLoop context = do
-  let config = Context.config context
+  let config = context.config
   App.run context . App.Log.info $
     F.sformat
       ("listening on" F.%+ F.shown F.%+ "port" F.%+ F.int)
-      (Config.host config)
-      (Witch.into @Int $ Config.port config)
+      config.host
+      (Witch.into @Int config.port)

--- a/source/library/Monadoc/Server/Middleware.hs
+++ b/source/library/Monadoc/Server/Middleware.hs
@@ -15,13 +15,13 @@ import qualified Network.Wai as Wai
 
 middleware :: (Stack.HasCallStack) => Context.Context -> Wai.Middleware
 middleware context =
-  AddRequestId.middleware (Context.key context)
+  AddRequestId.middleware context.key
     . LogResponses.middleware context
     . CacheResponses.middleware
-    . CompressResponses.middleware (Context.temporaryDirectory context)
-    . AddHeaders.middleware (Context.key context)
+    . CompressResponses.middleware context.temporaryDirectory
+    . AddHeaders.middleware context.key
     . HandleExceptions.middleware context
     . TimeoutHandlers.middleware
     . ServeStaticFiles.middleware
-      (Context.cacheContainer context)
-      (Config.data_ $ Context.config context)
+      context.cacheContainer
+      context.config.data_

--- a/source/library/Monadoc/Template/Common.hs
+++ b/source/library/Monadoc/Template/Common.hs
@@ -73,16 +73,14 @@ base ctx rt breadcrumbs title html = do
         . Html.div_ [Html.class_ "container py-2"]
         . Html.ol_ [Html.class_ "breadcrumb mb-0"]
         . Monad.forM_ breadcrumbs
-        $ \breadcrumb -> case Breadcrumb.route breadcrumb of
+        $ \breadcrumb -> case breadcrumb.route of
           Just bcrt ->
             Html.li_ [Html.class_ "breadcrumb-item"]
               . Html.a_ [Html.href_ $ route ctx bcrt]
-              . Html.toHtml
-              $ Breadcrumb.label breadcrumb
+              $ Html.toHtml breadcrumb.label
           Nothing ->
-            Html.li_ [Html.class_ "breadcrumb-item active"]
-              . Html.toHtml
-              $ Breadcrumb.label breadcrumb
+            Html.li_ [Html.class_ "breadcrumb-item active"] $
+              Html.toHtml breadcrumb.label
       Html.main_ [Html.class_ "my-3"] $
         Html.div_ [Html.class_ "container"] html
       Html.footer_ [Html.class_ "mb-5 mt-3 text-secondary"]
@@ -93,7 +91,7 @@ base ctx rt breadcrumbs title html = do
           Html.a_ [Html.class_ "link-secondary", Html.href_ github] "Monadoc"
           " version "
           Html.toHtml $ Witch.into @VersionNumber.VersionNumber Monadoc.version
-          let sha = Config.sha $ Context.config ctx
+          let sha = ctx.config.sha
           if Text.null sha
             then ""
             else do
@@ -115,7 +113,7 @@ route :: Context.Context -> Route.Route -> Text.Text
 route c r =
   let (p, q) = Route.render r
    in mconcat
-        [ Text.pack . Config.base $ Context.config c,
+        [ Text.pack c.config.base,
           Text.intercalate "/" p,
           if null q
             then Text.empty

--- a/source/library/Monadoc/Template/Home/Get.hs
+++ b/source/library/Monadoc/Template/Home/Get.hs
@@ -26,7 +26,7 @@ data Input = Input
 
 render :: Context.Context -> Input -> Html.Html ()
 render context input =
-  Common.base context Route.Home (breadcrumbs input) "Monadoc" $ do
+  Common.base context Route.Home input.breadcrumbs "Monadoc" $ do
     Html.h2_ "Core Libraries"
     Html.ul_ . Monad.forM_ coreLibraries $ \packageName ->
       Html.li_
@@ -34,30 +34,28 @@ render context input =
         $ Html.toHtml packageName
     Html.h2_ "Recent Uploads"
     Html.ul_ $ do
-      Monad.forM_ (rows input) $ \row -> Html.li_ $ do
+      Monad.forM_ input.rows $ \row -> Html.li_ $ do
         let (upload Sql.:. package Sql.:. version Sql.:. hackageUser Sql.:. _) = row
             reversion =
               Reversion.Reversion
-                { Reversion.revision = Upload.revision $ Model.value upload,
-                  Reversion.version = Version.number $ Model.value version
+                { Reversion.revision = upload.value.revision,
+                  Reversion.version = version.value.number
                 }
-            packageName = Package.name $ Model.value package
+            packageName = package.value.name
         Html.a_ [Html.href_ . Common.route context $ Route.Version packageName reversion] $ do
           Html.toHtml packageName
           "@"
           Html.toHtml reversion
         " uploaded "
-        Common.timestamp . Upload.uploadedAt $ Model.value upload
+        Common.timestamp upload.value.uploadedAt
         " by "
-        Html.a_ [Html.href_ . Common.route context . Route.User . HackageUser.name $ Model.value hackageUser]
-          . Html.toHtml
-          . HackageUser.name
-          $ Model.value hackageUser
+        Html.a_ [Html.href_ . Common.route context $ Route.User hackageUser.value.name] $
+          Html.toHtml hackageUser.value.name
         "."
-        Monad.when (Upload.isLatest $ Model.value upload) $ do
+        Monad.when upload.value.isLatest $ do
           " "
           Html.span_ [Html.class_ "badge bg-info-subtle text-info-emphasis"] "latest"
-        Monad.when (not . Upload.isPreferred $ Model.value upload) $ do
+        Monad.when (not $ upload.value.isPreferred) $ do
           " "
           Html.span_ [Html.class_ "badge bg-warning-subtle text-warning-emphasis"] "deprecated"
 

--- a/source/library/Monadoc/Template/Module/Get.hs
+++ b/source/library/Monadoc/Template/Module/Get.hs
@@ -34,18 +34,18 @@ data Input = Input
 
 render :: Context.Context -> Input -> Html.Html ()
 render context input = do
-  let packageName = Package.name . Model.value $ package input
+  let packageName = input.package.value.name
       reversion =
         Reversion.Reversion
-          { Reversion.version = Version.number . Model.value $ version input,
-            Reversion.revision = Upload.revision . Model.value $ upload input
+          { Reversion.version = input.version.value.number,
+            Reversion.revision = input.upload.value.revision
           }
       componentId =
         ComponentId.ComponentId
-          { ComponentId.type_ = Component.type_ . Model.value $ component input,
-            ComponentId.name = Component.name . Model.value $ component input
+          { ComponentId.type_ = input.component.value.type_,
+            ComponentId.name = input.component.value.name
           }
-      moduleName = Module.name . Model.value $ module_ input
+      moduleName = input.module_.value.name
       title =
         F.sformat
           ("Package" F.%+ F.stext F.%+ "version" F.%+ F.stext F.%+ "component" F.%+ F.stext F.%+ "module" F.%+ F.stext F.%+ ":: Monadoc")
@@ -54,13 +54,13 @@ render context input = do
           (Witch.from componentId)
           (Witch.from moduleName)
       route = Route.Module packageName reversion componentId moduleName
-  Common.base context route (breadcrumbs input) title $ do
-    Version.Get.showDeprecationWarning packageName reversion $ upload input
-    Version.Get.showLatestInfo context packageName (maybeLatest input) $ \rev ->
-      if hasModule input
+  Common.base context route input.breadcrumbs title $ do
+    Version.Get.showDeprecationWarning packageName reversion input.upload
+    Version.Get.showLatestInfo context packageName input.maybeLatest $ \rev ->
+      if input.hasModule
         then Just $ Route.Module packageName rev componentId moduleName
         else
-          if hasComponent input
+          if input.hasComponent
             then Just $ Route.Component packageName rev componentId
             else Nothing
     -- TODO: Include identifiers exported by the module. This will require
@@ -78,7 +78,7 @@ render context input = do
             F.sformat
               ("https://hackage.haskell.org/package/" F.% F.stext F.% "-" F.% F.stext F.% "/docs/" F.% F.string F.% ".html")
               (Witch.from packageName)
-              (Witch.from . Version.number . Model.value $ version input)
+              (Witch.from input.version.value.number)
               (List.intercalate "-" . Cabal.components $ Witch.from moduleName)
       Html.a_ [Html.href_ url] "on Hackage"
       " instead?"

--- a/source/library/Monadoc/Template/Search/Get.hs
+++ b/source/library/Monadoc/Template/Search/Get.hs
@@ -32,8 +32,8 @@ data Input = Input
 
 render :: Context.Context -> Input -> Html.Html ()
 render context input = do
-  let title = F.sformat ("Search" F.%+ F.stext F.%+ ":: Monadoc") (Witch.from $ query input)
-  Common.base context (Route.Search $ query input) (breadcrumbs input) title $ do
+  let title = F.sformat ("Search" F.%+ F.stext F.%+ ":: Monadoc") (Witch.from input.query)
+  Common.base context (Route.Search input.query) input.breadcrumbs title $ do
     Html.h2_ "Search"
     Html.form_
       [ Html.action_ . Common.route context . Route.Search $ Witch.from @Text.Text "",
@@ -45,47 +45,47 @@ render context input = do
             Html.name_ "query",
             Html.placeholder_ "traverse",
             Html.type_ "search",
-            Html.value_ . Witch.into @Text.Text $ query input
+            Html.value_ $ Witch.into @Text.Text input.query
           ]
         Html.button_
           [ Html.class_ "btn btn-primary",
             Html.type_ "submit"
           ]
           "Search"
-    Monad.when (not . Search.isBlank $ query input) $ do
+    Monad.when (not $ Search.isBlank input.query) $ do
       Html.h3_ "Packages"
-      if null $ packages input
+      if null input.packages
         then Html.p_ "None found."
-        else Html.ul_ . Monad.forM_ (packages input) $ \package -> do
-          let name = Package.name $ Model.value package
+        else Html.ul_ . Monad.forM_ input.packages $ \package -> do
+          let name = package.value.name
           Html.li_
             . Html.a_ [Html.href_ . Common.route context $ Route.Package name]
             $ Html.toHtml name
       Html.h3_ "Modules"
-      if null $ modules input
+      if null input.modules
         then Html.p_ "None found."
-        else Html.ul_ . Monad.forM_ (modules input) $ \(package Sql.:. version Sql.:. upload Sql.:. component Sql.:. module_) -> do
-          let packageName = Package.name $ Model.value package
+        else Html.ul_ . Monad.forM_ input.modules $ \(package Sql.:. version Sql.:. upload Sql.:. component Sql.:. module_) -> do
+          let packageName = package.value.name
               reversion =
                 Reversion.Reversion
-                  { Reversion.version = Version.number $ Model.value version,
-                    Reversion.revision = Upload.revision $ Model.value upload
+                  { Reversion.version = version.value.number,
+                    Reversion.revision = upload.value.revision
                   }
               componentId =
                 ComponentId.ComponentId
-                  { ComponentId.type_ = Component.type_ $ Model.value component,
-                    ComponentId.name = Component.name $ Model.value component
+                  { ComponentId.type_ = component.value.type_,
+                    ComponentId.name = component.value.name
                   }
-              moduleName = Module.name $ Model.value module_
+              moduleName = module_.value.name
           Html.li_ $ do
             Html.a_ [Html.href_ . Common.route context $ Route.Module packageName reversion componentId moduleName] $ Html.toHtml moduleName
             " in "
             Html.toHtml componentId
       Html.h3_ "Users"
-      if null $ hackageUsers input
+      if null input.hackageUsers
         then Html.p_ "None found."
-        else Html.ul_ . Monad.forM_ (hackageUsers input) $ \hackageUser -> do
-          let name = HackageUser.name $ Model.value hackageUser
+        else Html.ul_ . Monad.forM_ input.hackageUsers $ \hackageUser -> do
+          let name = hackageUser.value.name
           Html.li_
             . Html.a_ [Html.href_ . Common.route context $ Route.User name]
             $ Html.toHtml name

--- a/source/library/Monadoc/Template/User/Get.hs
+++ b/source/library/Monadoc/Template/User/Get.hs
@@ -26,35 +26,33 @@ data Input = Input
 
 render :: Context.Context -> Input -> Html.Html ()
 render context input = do
-  let hackageUserName = HackageUser.name . Model.value $ hackageUser input
+  let hackageUserName = input.hackageUser.value.name
       route = Route.User hackageUserName
       title = F.sformat ("User" F.%+ F.stext F.%+ ":: Monadoc") (Witch.from hackageUserName)
-  Common.base context route (breadcrumbs input) title $ do
-    Html.h2_ . Html.toHtml . HackageUser.name . Model.value $ hackageUser input
+  Common.base context route input.breadcrumbs title $ do
+    Html.h2_ . Html.toHtml $ input.hackageUser.value.name
     Html.h3_ "Uploads"
-    Html.ul_ . Monad.forM_ (rows input) $ \(upload Sql.:. version Sql.:. package) -> Html.li_ $ do
+    Html.ul_ . Monad.forM_ input.rows $ \(upload Sql.:. version Sql.:. package) -> Html.li_ $ do
       let reversion =
             Reversion.Reversion
-              { Reversion.revision = Upload.revision $ Model.value upload,
-                Reversion.version = Version.number $ Model.value version
+              { Reversion.revision = upload.value.revision,
+                Reversion.version = version.value.number
               }
-      Html.a_ [Html.href_ . Common.route context $ Route.Version (Package.name $ Model.value package) reversion] $ do
-        Html.toHtml . Package.name $ Model.value package
+      Html.a_ [Html.href_ . Common.route context $ Route.Version package.value.name reversion] $ do
+        Html.toHtml package.value.name
         "@"
         Html.toHtml reversion
       " uploaded "
-      Common.timestamp . Upload.uploadedAt $ Model.value upload
+      Common.timestamp upload.value.uploadedAt
       "."
-      Monad.when (Upload.isLatest $ Model.value upload) $ do
+      Monad.when upload.value.isLatest $ do
         " "
         Html.span_ [Html.class_ "badge bg-info-subtle text-info-emphasis"] "latest"
-      Monad.when (not . Upload.isPreferred $ Model.value upload) $ do
+      Monad.when (not upload.value.isPreferred) $ do
         " "
         Html.span_ [Html.class_ "badge bg-warning-subtle text-warning-emphasis"] "deprecated"
     Html.h3_ "Packages"
-    Html.ul_ . Monad.forM_ (packages input) $ \package ->
+    Html.ul_ . Monad.forM_ input.packages $ \package ->
       Html.li_
-        . Html.a_ [Html.href_ . Common.route context . Route.Package . Package.name $ Model.value package]
-        . Html.toHtml
-        . Package.name
-        $ Model.value package
+        . Html.a_ [Html.href_ . Common.route context $ Route.Package package.value.name]
+        $ Html.toHtml package.value.name

--- a/source/library/Monadoc/Template/Version/Get.hs
+++ b/source/library/Monadoc/Template/Version/Get.hs
@@ -88,21 +88,21 @@ render context input = do
         . Haddock.parseParas Nothing
         $ maybe "" (Witch.into @String) input.packageMeta.value.description
       Html.dt_ "Author"
-      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.author
+      Html.dd_ $ maybe "n/a" Html.toHtml input.packageMeta.value.author
       Html.dt_ "Bug reports"
-      Html.dd_ . maybe "n/a" autoLinkUrl $ input.packageMeta.value.bugReports
+      Html.dd_ $ maybe "n/a" autoLinkUrl input.packageMeta.value.bugReports
       Html.dt_ "Category"
-      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.category
+      Html.dd_ $ maybe "n/a" Html.toHtml input.packageMeta.value.category
       Html.dt_ "Copyright"
-      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.copyright
+      Html.dd_ $ maybe "n/a" Html.toHtml input.packageMeta.value.copyright
       Html.dt_ "Homepage"
-      Html.dd_ . maybe "n/a" autoLinkUrl $ input.packageMeta.value.homepage
+      Html.dd_ $ maybe "n/a" autoLinkUrl input.packageMeta.value.homepage
       Html.dt_ "Maintainer"
-      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.maintainer
+      Html.dd_ $ maybe "n/a" Html.toHtml input.packageMeta.value.maintainer
       Html.dt_ "Package URL"
-      Html.dd_ . maybe "n/a" autoLinkUrl $ input.packageMeta.value.pkgUrl
+      Html.dd_ $ maybe "n/a" autoLinkUrl input.packageMeta.value.pkgUrl
       Html.dt_ "Stability"
-      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.stability
+      Html.dd_ $ maybe "n/a" Html.toHtml input.packageMeta.value.stability
     Html.h3_ "Components"
     Html.ul_ . Monad.forM_ (sortComponents packageName $ fmap (\(_ Sql.:. c) -> c) input.components) $ \component -> Html.li_ $ do
       let componentId =

--- a/source/library/Monadoc/Template/Version/Get.hs
+++ b/source/library/Monadoc/Template/Version/Get.hs
@@ -46,9 +46,9 @@ data Input = Input
 
 render :: Context.Context -> Input -> Html.Html ()
 render context input = do
-  let packageName = Package.name . Model.value $ package input
-      versionNumber = Version.number . Model.value $ version input
-      revision = Upload.revision . Model.value $ upload input
+  let packageName = input.package.value.name
+      versionNumber = input.version.value.number
+      revision = input.upload.value.revision
       reversion =
         Reversion.Reversion
           { Reversion.revision = revision,
@@ -60,9 +60,9 @@ render context input = do
           ("Package" F.%+ F.stext F.%+ "version" F.%+ F.stext F.%+ ":: Monadoc")
           (Witch.from packageName)
           (Witch.from reversion)
-  Common.base context route (breadcrumbs input) title $ do
-    showDeprecationWarning packageName reversion $ upload input
-    showLatestInfo context packageName (maybeLatest input) $ const Nothing
+  Common.base context route input.breadcrumbs title $ do
+    showDeprecationWarning packageName reversion input.upload
+    showLatestInfo context packageName input.maybeLatest $ const Nothing
     Html.h2_ $ Html.toHtml packageName
     Html.p_ $ do
       "Version "
@@ -70,18 +70,15 @@ render context input = do
       " revision "
       Html.toHtml revision
       " uploaded "
-      Common.timestamp . Upload.uploadedAt . Model.value $ upload input
+      Common.timestamp input.upload.value.uploadedAt
       " by "
-      Html.a_ [Html.href_ . Common.route context . Route.User . HackageUser.name . Model.value $ hackageUser input]
-        . Html.toHtml
-        . HackageUser.name
-        . Model.value
-        $ hackageUser input
+      Html.a_ [Html.href_ . Common.route context $ Route.User input.hackageUser.value.name] $
+        Html.toHtml input.hackageUser.value.name
       "."
     Html.h3_ "Package meta"
     Html.dl_ $ do
       Html.dt_ "Synopsis"
-      Html.dd_ . maybe "n/a" Html.toHtml . PackageMeta.synopsis . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.synopsis
       Html.dt_ "Description"
       Html.dd_
         . Html.toHtml
@@ -89,32 +86,29 @@ render context input = do
         . Haddock.overIdentifier (curry Just)
         . Haddock._doc
         . Haddock.parseParas Nothing
-        . maybe "" (Witch.into @String)
-        . PackageMeta.description
-        . Model.value
-        $ packageMeta input
+        $ maybe "" (Witch.into @String) input.packageMeta.value.description
       Html.dt_ "Author"
-      Html.dd_ . maybe "n/a" Html.toHtml . PackageMeta.author . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.author
       Html.dt_ "Bug reports"
-      Html.dd_ . maybe "n/a" autoLinkUrl . PackageMeta.bugReports . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" autoLinkUrl $ input.packageMeta.value.bugReports
       Html.dt_ "Category"
-      Html.dd_ . maybe "n/a" Html.toHtml . PackageMeta.category . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.category
       Html.dt_ "Copyright"
-      Html.dd_ . maybe "n/a" Html.toHtml . PackageMeta.copyright . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.copyright
       Html.dt_ "Homepage"
-      Html.dd_ . maybe "n/a" autoLinkUrl . PackageMeta.homepage . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" autoLinkUrl $ input.packageMeta.value.homepage
       Html.dt_ "Maintainer"
-      Html.dd_ . maybe "n/a" Html.toHtml . PackageMeta.maintainer . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.maintainer
       Html.dt_ "Package URL"
-      Html.dd_ . maybe "n/a" autoLinkUrl . PackageMeta.pkgUrl . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" autoLinkUrl $ input.packageMeta.value.pkgUrl
       Html.dt_ "Stability"
-      Html.dd_ . maybe "n/a" Html.toHtml . PackageMeta.stability . Model.value $ packageMeta input
+      Html.dd_ . maybe "n/a" Html.toHtml $ input.packageMeta.value.stability
     Html.h3_ "Components"
-    Html.ul_ . Monad.forM_ (sortComponents packageName . fmap (\(_ Sql.:. c) -> c) $ components input) $ \component -> Html.li_ $ do
+    Html.ul_ . Monad.forM_ (sortComponents packageName $ fmap (\(_ Sql.:. c) -> c) input.components) $ \component -> Html.li_ $ do
       let componentId =
             ComponentId.ComponentId
-              { ComponentId.type_ = Component.type_ $ Model.value component,
-                ComponentId.name = Component.name $ Model.value component
+              { ComponentId.type_ = component.value.type_,
+                ComponentId.name = component.value.name
               }
       Html.a_ [Html.href_ . Common.route context $ Route.Component packageName reversion componentId] $
         Html.toHtml componentId
@@ -133,7 +127,7 @@ autoLinkUrl text =
 
 showDeprecationWarning :: PackageName.PackageName -> Reversion.Reversion -> Upload.Model -> Html.Html ()
 showDeprecationWarning pkg rev upl = do
-  Monad.when (not . Upload.isPreferred $ Model.value upl)
+  Monad.when (not upl.value.isPreferred)
     . Html.div_ [Html.class_ "alert alert-warning"]
     $ do
       "Version "
@@ -157,8 +151,8 @@ showLatestInfo context packageName m makeRoute =
       " is "
       let reversion =
             Reversion.Reversion
-              { Reversion.version = Version.number $ Model.value ver,
-                Reversion.revision = Upload.revision $ Model.value upl
+              { Reversion.version = ver.value.number,
+                Reversion.revision = upl.value.revision
               }
           route = Maybe.fromMaybe (Route.Version packageName reversion) $ makeRoute reversion
       Html.a_
@@ -170,10 +164,10 @@ showLatestInfo context packageName m makeRoute =
 
 sortComponents :: PackageName.PackageName -> [Component.Model] -> [Component.Model]
 sortComponents packageName = List.sortOn $ \component ->
-  let it = Model.value component
-   in ( Component.type_ it /= ComponentType.Library || Component.name it /= Witch.from packageName,
-        Witch.into @String $ Component.type_ it,
-        Witch.into @String $ Component.name it
+  let it = component.value
+   in ( it.type_ /= ComponentType.Library || it.name /= Witch.from packageName,
+        Witch.into @String it.type_,
+        Witch.into @String it.name
       )
 
 markup :: Context.Context -> Haddock.DocMarkupH Void.Void (Haddock.Namespace, String) (Html.Html ())

--- a/source/library/Monadoc/Type/ComponentId.hs
+++ b/source/library/Monadoc/Type/ComponentId.hs
@@ -16,15 +16,15 @@ data ComponentId = ComponentId
 instance Witch.TryFrom String ComponentId where
   tryFrom = Witch.maybeTryFrom $ \string -> do
     let (before, after) = break ((==) ':') string
-    ct <- Either.hush $ Witch.tryFrom before
-    cn <- Either.hush . Witch.tryFrom $ drop 1 after
-    pure ComponentId {type_ = ct, name = cn}
+    type_ <- Either.hush $ Witch.tryFrom before
+    name <- Either.hush . Witch.tryFrom $ drop 1 after
+    pure ComponentId {type_ = type_, name = name}
 
 instance Witch.TryFrom Text.Text ComponentId where
   tryFrom = Witch.eitherTryFrom $ Witch.tryFrom . Witch.into @String
 
 instance Witch.From ComponentId String where
-  from ci = Witch.from (type_ ci) <> ":" <> Witch.from (name ci)
+  from ci = Witch.from ci.type_ <> ":" <> Witch.from ci.name
 
 instance Witch.From ComponentId Text.Text where
   from = Witch.via @String

--- a/source/library/Monadoc/Type/Context.hs
+++ b/source/library/Monadoc/Type/Context.hs
@@ -34,21 +34,21 @@ data Context = Context
 fromConfig :: String -> Config.Config -> IO Context
 fromConfig name cfg = do
   let version = Version.showVersion Monadoc.version
-  Monad.when (Config.help cfg) $ do
+  Monad.when cfg.help $ do
     let header = unwords [name, "version", version]
     Say.sayString
       . List.dropWhileEnd Char.isSpace
       $ Console.usageInfo header Flag.options
     Exception.throwM Exit.ExitSuccess
-  Monad.when (Config.version cfg) $ do
+  Monad.when cfg.version $ do
     Say.sayString version
     Exception.throwM Exit.ExitSuccess
   let poolConfig =
         Pool.defaultPoolConfig
-          (Sql.open $ Config.sql cfg)
+          (Sql.open cfg.sql)
           Sql.close
           60
-          (if Config.sql cfg == ":memory:" then 1 else 8)
+          (if cfg.sql == ":memory:" then 1 else 8)
   let cachingStrategy = Static.CustomCaching $ \fileMeta ->
         [ (Http.hCacheControl, "max-age=604800, stale-while-revalidate=86400"),
           (Http.hETag, Static.fm_etag fileMeta)

--- a/source/library/Monadoc/Type/Icon.hs
+++ b/source/library/Monadoc/Type/Icon.hs
@@ -15,16 +15,16 @@ data Icon = Icon
 instance Aeson.ToJSON Icon where
   toJSON icon =
     Aeson.object
-      [ "sizes" Aeson..= sizes icon,
-        "purpose" Aeson..= purpose icon,
-        "src" Aeson..= src icon,
-        "type" Aeson..= type_ icon
+      [ "sizes" Aeson..= icon.sizes,
+        "purpose" Aeson..= icon.purpose,
+        "src" Aeson..= icon.src,
+        "type" Aeson..= icon.type_
       ]
 
 instance Hashable.Hashable Icon where
   hashWithSalt s x =
     s
-      `Hashable.hashWithSalt` sizes x
-      `Hashable.hashWithSalt` purpose x
-      `Hashable.hashWithSalt` src x
-      `Hashable.hashWithSalt` type_ x
+      `Hashable.hashWithSalt` x.sizes
+      `Hashable.hashWithSalt` x.purpose
+      `Hashable.hashWithSalt` x.src
+      `Hashable.hashWithSalt` x.type_

--- a/source/library/Monadoc/Type/Manifest.hs
+++ b/source/library/Monadoc/Type/Manifest.hs
@@ -19,22 +19,22 @@ data Manifest = Manifest
 instance Aeson.ToJSON Manifest where
   toJSON manifest =
     Aeson.object
-      [ "background_color" Aeson..= backgroundColor manifest,
-        "display" Aeson..= display manifest,
-        "icons" Aeson..= icons manifest,
-        "name" Aeson..= name manifest,
-        "$schema" Aeson..= schema manifest,
-        "start_url" Aeson..= startUrl manifest,
-        "theme_color" Aeson..= themeColor manifest
+      [ "background_color" Aeson..= manifest.backgroundColor,
+        "display" Aeson..= manifest.display,
+        "icons" Aeson..= manifest.icons,
+        "name" Aeson..= manifest.name,
+        "$schema" Aeson..= manifest.schema,
+        "start_url" Aeson..= manifest.startUrl,
+        "theme_color" Aeson..= manifest.themeColor
       ]
 
 instance Hashable.Hashable Manifest where
   hashWithSalt s x =
     s
-      `Hashable.hashWithSalt` backgroundColor x
-      `Hashable.hashWithSalt` display x
-      `Hashable.hashWithSalt` icons x
-      `Hashable.hashWithSalt` name x
-      `Hashable.hashWithSalt` schema x
-      `Hashable.hashWithSalt` startUrl x
-      `Hashable.hashWithSalt` themeColor x
+      `Hashable.hashWithSalt` x.backgroundColor
+      `Hashable.hashWithSalt` x.display
+      `Hashable.hashWithSalt` x.icons
+      `Hashable.hashWithSalt` x.name
+      `Hashable.hashWithSalt` x.schema
+      `Hashable.hashWithSalt` x.startUrl
+      `Hashable.hashWithSalt` x.themeColor

--- a/source/library/Monadoc/Type/Model.hs
+++ b/source/library/Monadoc/Type/Model.hs
@@ -15,7 +15,7 @@ instance (Sql.FromRow a) => Sql.FromRow (Model a) where
   fromRow = Model <$> Sql.field <*> Sql.fromRow
 
 instance (Sql.ToRow a) => Sql.ToRow (Model a) where
-  toRow model = Sql.toField (key model) : Sql.toRow (value model)
+  toRow model = Sql.toField model.key : Sql.toRow model.value
 
 instance (QuickCheck.Arbitrary a) => QuickCheck.Arbitrary (Model a) where
   arbitrary =

--- a/source/library/Monadoc/Type/Reversion.hs
+++ b/source/library/Monadoc/Type/Reversion.hs
@@ -20,9 +20,9 @@ data Reversion = Reversion
 
 instance Witch.From Reversion String where
   from reversion =
-    Witch.into @String (version reversion)
+    Witch.into @String reversion.version
       <> "-"
-      <> Witch.into @String (revision reversion)
+      <> Witch.into @String reversion.revision
 
 instance Witch.From Reversion Text.Text where
   from = Witch.via @String


### PR DESCRIPTION
This started as an experiment. I liked what I saw, so I kept making changes. The key thing about this for me was enabling `NoFieldSelectors` along with `OverloadedRecordDot`. That way I'm forced to change stuff like `Model.value foo` into `foo.value`. Without that, both formats would be allowed, which I think would make the code base messy. However it also requires changing everything all at once. Although I suppose I could've just enabled `OverloadedRecordDot` for the whole project, then gone file-by-file enabling `NoFieldSelectors`. 