### PR TITLE
Switch from `PackageInfo_*` to `Paths_*`

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -194,6 +194,24 @@
         }
       ]
     },
+    "gild": {
+      "name": "Gild",
+      "runs-on": "ubuntu-22.04",
+      "steps": [
+        {
+          "uses": "actions/checkout@v4"
+        },
+        {
+          "uses": "tfausak/cabal-gild-setup-action@v2",
+          "with": {
+            "version": "1.3.0.1"
+          }
+        },
+        {
+          "run": "cabal-gild --input monadoc.cabal --mode check"
+        }
+      ]
+    },
     "hlint": {
       "name": "HLint",
       "runs-on": "ubuntu-22.04",

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -50,7 +50,7 @@ common executable
 
 library
   import:             library
-  autogen-modules:    PackageInfo_monadoc
+  autogen-modules:    Paths_monadoc
   build-depends:
     , aeson ^>=2.2.1.0
     , async ^>=2.2.5
@@ -364,7 +364,7 @@ library
     Monadoc.Type.UrlSpec
     Monadoc.Type.VersionNumberSpec
     MonadocSpec
-    PackageInfo_monadoc
+    Paths_monadoc
 
 executable monadoc
   import:         executable

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               monadoc
-version:            0.2024.1.25
+version:            0.2024.4.2
 build-type:         Simple
 category:           Documentation
 data-dir:           data

--- a/monadoc.cabal
+++ b/monadoc.cabal
@@ -1,9 +1,9 @@
-cabal-version:      3.0
-name:               monadoc
-version:            0.2024.4.2
-build-type:         Simple
-category:           Documentation
-data-dir:           data
+cabal-version: 3.0
+name: monadoc
+version: 0.2024.4.2
+build-type: Simple
+category: Documentation
+data-dir: data
 data-files:
   apple-touch-icon.png
   bootstrap.css
@@ -13,89 +13,98 @@ data-files:
   mathjax/**/*.woff
   monadoc.js
 
-description:        Monadoc provides worse Haskell documentation.
+description: Monadoc provides worse Haskell documentation.
 extra-source-files: README.markdown
-license-file:       LICENSE.txt
-license:            MIT
-maintainer:         Taylor Fausak
-synopsis:           Worse Haskell documentation.
+license-file: LICENSE.txt
+license: MIT
+maintainer: Taylor Fausak
+synopsis: Worse Haskell documentation.
 
 source-repository head
   location: https://github.com/tfausak/monadoc
-  type:     git
+  type: git
 
 flag pedantic
-  default:     False
+  default: False
   description: Turns warnings into errors.
-  manual:      True
+  manual: True
 
 common library
-  build-depends:    base ^>=4.19.0.0
+  build-depends: base ^>=4.19.0.0
   default-language: Haskell2010
   ghc-options:
-    -Weverything -Wno-all-missed-specialisations -Wno-implicit-prelude
-    -Wno-missed-specialisations -Wno-missing-deriving-strategies
-    -Wno-missing-export-lists -Wno-missing-exported-signatures
-    -Wno-missing-kind-signatures -Wno-missing-role-annotations
-    -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
-    -Wno-safe -Wno-unsafe
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-implicit-prelude
+    -Wno-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-export-lists
+    -Wno-missing-exported-signatures
+    -Wno-missing-kind-signatures
+    -Wno-missing-role-annotations
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
 
   if flag(pedantic)
     ghc-options: -Werror
 
 common executable
-  import:        library
+  import: library
   build-depends: monadoc
-  ghc-options:   -rtsopts -threaded
+  ghc-options:
+    -rtsopts
+    -threaded
 
 library
-  import:             library
-  autogen-modules:    Paths_monadoc
+  import: library
+  autogen-modules: Paths_monadoc
   build-depends:
-    , aeson ^>=2.2.1.0
-    , async ^>=2.2.5
-    , bytestring ^>=0.12.0.2
-    , Cabal-syntax ^>=3.10.2.0
-    , case-insensitive ^>=1.2.1.0
-    , containers ^>=0.6.8
-    , crypton ^>=0.31
-    , direct-sqlite ^>=2.3.29
-    , directory ^>=1.3.8.1
-    , exceptions ^>=0.10.7
-    , filepath ^>=1.4.100.4
-    , formatting ^>=7.2.0
-    , haddock-library ^>=1.11.0
-    , hashable ^>=1.4.3.0
-    , hspec ^>=2.11.7
-    , http-client ^>=0.7.16
-    , http-client-tls ^>=0.3.6.3
-    , http-types ^>=0.12.4
-    , lucid2 ^>=0.0.20230706
-    , memory ^>=0.18.0
-    , monad-control ^>=1.0.3.1
-    , monad-loops ^>=0.4.3
-    , network-uri ^>=2.6.4.2
-    , patrol ^>=1.0.0.7
-    , QuickCheck ^>=2.14.3
-    , random ^>=1.2.1.1
-    , resource-pool ^>=0.4.0.0
-    , saturn:{saturn, spec} ^>=1.0.0.3
-    , say ^>=0.1.0.1
-    , sqlite-simple ^>=0.4.19.0
-    , stm ^>=2.5.2.1
-    , tar ^>=0.6.0.0
-    , temporary ^>=1.3
-    , text ^>=2.1
-    , time ^>=1.12.2
-    , transformers ^>=0.6.1.0
-    , uuid ^>=1.3.15
-    , vault ^>=0.3.1.5
-    , wai ^>=3.2.4
-    , wai-extra ^>=3.1.14
-    , wai-middleware-static ^>=0.9.2
-    , warp ^>=3.4.0
-    , witch ^>=1.2.0.4
-    , zlib ^>=0.6.3.0
+    Cabal-syntax ^>=3.10.2.0,
+    QuickCheck ^>=2.14.3,
+    aeson ^>=2.2.1.0,
+    async ^>=2.2.5,
+    bytestring ^>=0.12.0.2,
+    case-insensitive ^>=1.2.1.0,
+    containers ^>=0.6.8,
+    crypton ^>=0.31,
+    direct-sqlite ^>=2.3.29,
+    directory ^>=1.3.8.1,
+    exceptions ^>=0.10.7,
+    filepath ^>=1.4.100.4,
+    formatting ^>=7.2.0,
+    haddock-library ^>=1.11.0,
+    hashable ^>=1.4.3.0,
+    hspec ^>=2.11.7,
+    http-client ^>=0.7.16,
+    http-client-tls ^>=0.3.6.3,
+    http-types ^>=0.12.4,
+    lucid2 ^>=0.0.20230706,
+    memory ^>=0.18.0,
+    monad-control ^>=1.0.3.1,
+    monad-loops ^>=0.4.3,
+    network-uri ^>=2.6.4.2,
+    patrol ^>=1.0.0.7,
+    random ^>=1.2.1.1,
+    resource-pool ^>=0.4.0.0,
+    saturn:{saturn, spec} ^>=1.0.0.3,
+    say ^>=0.1.0.1,
+    sqlite-simple ^>=0.4.19.0,
+    stm ^>=2.5.2.1,
+    tar ^>=0.6.0.0,
+    temporary ^>=1.3,
+    text ^>=2.1,
+    time ^>=1.12.2,
+    transformers ^>=0.6.1.0,
+    uuid ^>=1.3.15,
+    vault ^>=0.3.1.5,
+    wai ^>=3.2.4,
+    wai-extra ^>=3.1.14,
+    wai-middleware-static ^>=0.9.2,
+    warp ^>=3.4.0,
+    witch ^>=1.2.0.4,
+    zlib ^>=0.6.3.0,
 
   default-extensions:
     AllowAmbiguousTypes
@@ -286,7 +295,7 @@ library
     Monadoc.Type.VersionNumber
     Monadoc.Worker.Main
 
-  hs-source-dirs:     source/library
+  hs-source-dirs: source/library
   other-modules:
     Monadoc.Action.Blob.InsertSpec
     Monadoc.Action.Blob.UpsertSpec
@@ -367,12 +376,12 @@ library
     Paths_monadoc
 
 executable monadoc
-  import:         executable
+  import: executable
   hs-source-dirs: source/executable
-  main-is:        Main.hs
+  main-is: Main.hs
 
 test-suite monadoc-test-suite
-  import:         executable
+  import: executable
   hs-source-dirs: source/test-suite
-  main-is:        Main.hs
-  type:           exitcode-stdio-1.0
+  main-is: Main.hs
+  type: exitcode-stdio-1.0

--- a/source/library/Monadoc/Action/Exception/NotifySentry.hs
+++ b/source/library/Monadoc/Action/Exception/NotifySentry.hs
@@ -21,7 +21,7 @@ import qualified Monadoc.Type.App as App
 import qualified Monadoc.Type.Config as Config
 import qualified Monadoc.Type.Context as Context
 import qualified Network.Wai.Handler.Warp as Warp
-import qualified PackageInfo_monadoc as Monadoc
+import qualified Paths_monadoc as Monadoc
 import qualified Patrol
 import qualified Patrol.Client as Patrol
 import qualified Patrol.Type.Event as Patrol.Event

--- a/source/library/Monadoc/Extra/HttpClient.hs
+++ b/source/library/Monadoc/Extra/HttpClient.hs
@@ -5,7 +5,7 @@ import qualified Data.Version as Version
 import qualified Monadoc.Middleware.AddHeaders as AddHeaders
 import qualified Network.HTTP.Client as Client
 import qualified Network.HTTP.Types as Http
-import qualified PackageInfo_monadoc as Monadoc
+import qualified Paths_monadoc as Monadoc
 import qualified Witch
 
 ensureUserAgent :: Client.Request -> Client.Request

--- a/source/library/Monadoc/Template/Common.hs
+++ b/source/library/Monadoc/Template/Common.hs
@@ -14,7 +14,7 @@ import qualified Monadoc.Type.Search as Search
 import qualified Monadoc.Type.Timestamp as Timestamp
 import qualified Monadoc.Type.VersionNumber as VersionNumber
 import qualified Network.HTTP.Types as Http
-import qualified PackageInfo_monadoc as Monadoc
+import qualified Paths_monadoc as Monadoc
 import qualified Witch
 
 base ::

--- a/source/library/Monadoc/Type/Context.hs
+++ b/source/library/Monadoc/Type/Context.hs
@@ -16,7 +16,7 @@ import qualified Network.HTTP.Client.TLS as Tls
 import qualified Network.HTTP.Types as Http
 import qualified Network.HTTP.Types.Header as Http
 import qualified Network.Wai.Middleware.Static as Static
-import qualified PackageInfo_monadoc as Monadoc
+import qualified Paths_monadoc as Monadoc
 import qualified Say
 import qualified System.Console.GetOpt as Console
 import qualified System.Directory as Directory

--- a/weeder.toml
+++ b/weeder.toml
@@ -2,6 +2,6 @@ roots = [
   "^Main[.]main$",
   "^Monadoc[.]Main[.]Executable[.]executable$",
   "^Monadoc[.]Main[.]TestSuite[.]testSuite$",
-  "^PackageInfo_",
+  "^Paths_",
 ]
 type-class-roots = true


### PR DESCRIPTION
Reverts #41. 

The `PackageInfo_*` module is in a weird limbo. It was added to Cabal without a proper check in `cabal check`. Not knowing this, I used it and didn't think about it. But now in a minor release of Cabal the check has been added. It suggests upgrading to a version of Cabal that hasn't been released yet: 

```
Warning: To use the autogenerated module PackageInfo_* you need to specify
`cabal-version: 3.12` or higher. This is not possible in `cabal 3.10`. To use
this feature and be able to upload your package to Hackage, download `cabal
3.12`!
```

https://github.com/tfausak/monadoc/actions/runs/8501851243/job/23285238478#step:3:7

I still think `PackageInfo_*` is the right way to go, but it's not worth trying to work around this right now. Perhaps when Cabal 3.12 is released I can revisit this. 